### PR TITLE
Add init file to make the package discoverable in the CI

### DIFF
--- a/plugins/metrics/__init__.py
+++ b/plugins/metrics/__init__.py
@@ -1,0 +1,2 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
### Description
Add init file to make the package discoverable in the CI

### Issues Resolved
https://github.com/opensearch-project/oscar-ai-bot/actions/runs/22505096293/job/65202343048

```
Traceback (most recent call last):
  File "/home/runner/work/oscar-ai-bot/oscar-ai-bot/app.py", line 19, in <module>
    from plugins.metrics.build import MetricsBuildPlugin
ModuleNotFoundError: No module named 'plugins.metrics.build'
python3 app.py: Subprocess exited with error 1

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
