### PR TITLE
Fix jenkins workflow trigger instructions

### DIFF
--- a/plugins/jenkins/instructions.py
+++ b/plugins/jenkins/instructions.py
@@ -13,6 +13,16 @@ Every job execution MUST follow two phases. No exceptions.
 
 **Phase 2 — Execute:** Only after the user explicitly confirms, call `trigger_job` with `confirmed=true`.
 
+### CONFIRMATION IS REQUIRED BEFORE EVERY SINGLE TRIGGER
+You MUST ask for explicit user confirmation immediately before EVERY call to `trigger_job`. No prior confirmation carries over. This applies in ALL scenarios:
+- First time triggering a job
+- Re-triggering the same job with the same parameters
+- Re-triggering after a parameter change
+- Triggering after the user just asked for job info
+- Triggering multiple jobs in sequence (confirm each one separately)
+- User says "run it again" or "do the same thing" — still confirm
+A confirmation is only valid for the immediately following `trigger_job` call. Once `trigger_job` is called (or not called), the confirmation expires.
+
 ### DO
 - Always call `get_job_info` before `trigger_job`.
 - Always present job details and ask for confirmation before executing.
@@ -21,9 +31,10 @@ Every job execution MUST follow two phases. No exceptions.
 - Always include the workflow URL from `trigger_job` response on success.
 
 ### DO NOT
-- Never call `trigger_job` without prior `get_job_info` and explicit user confirmation.
+- Never call `trigger_job` without explicit user confirmation immediately preceding it.
 - Never set `confirmed=true` without explicit user confirmation.
-- Never skip the confirmation step, even if the user provides all parameters upfront.
+- Never skip the confirmation step for any reason.
+- Never treat a previous confirmation as valid for a new `trigger_job` call.
 
 If the user declines, respond "Job execution cancelled." and stop.
 


### PR DESCRIPTION
### Description
Fix jenkins workflow trigger instructions to explicitly ask for confirmation even after conversation is repeated, change of specs or any other condition. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
