### PR TITLE
Deduplicate metrics IAM roles, source cross-account role ARN from env var, and use GET for OpenSearch queries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,8 +59,8 @@
 # ============================================================
 # METRICS PLUGIN
 # ============================================================
-# Sensitive values (METRICS_CROSS_ACCOUNT_ROLE_ARN, OPENSEARCH_HOST) are stored
-# in Secrets Manager — see plugins/metrics/README.md for setup instructions.
+# OPENSEARCH_HOST is stored in Secrets Manager — see plugins/metrics/README.md.
+# METRICS_CROSS_ACCOUNT_ROLE_ARN=arn:aws:iam::123456789012:role/YourCrossAccountRole
 #
 # CDK Environment Variables:
 # OPENSEARCH_REGION=us-east-1

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Create Production change-set for approval
         id: prod_stack_diff
+        env:
+          METRICS_CROSS_ACCOUNT_ROLE_ARN: ${{ secrets.METRICS_CROSS_ACCOUNT_ROLE }}
         run: |
           cp deployment/prod.env .env
           pipenv run cdk diff -c ENVIRONMENT=prod | sed -E 's/[0-9]{12}/[MASKED]/g' > prod_diff.txt
@@ -99,6 +101,8 @@ jobs:
             </details>
 
       - name: Deploy Production stacks
+        env:
+          METRICS_CROSS_ACCOUNT_ROLE_ARN: ${{ secrets.METRICS_CROSS_ACCOUNT_ROLE }}
         run: |
           cp deployment/prod.env .env
           pipenv run cdk deploy "*" --require-approval=never -c ENVIRONMENT=prod

--- a/deployment/prod.env
+++ b/deployment/prod.env
@@ -2,3 +2,9 @@
 # JENKINS PLUGIN
 # ============================================================
  JENKINSFILE_IGNORE_LIST=jenkins/gradle,jenkins/legacy
+
+# ============================================================
+# METRICS PLUGIN
+# ============================================================
+# Metrics configuration is managed via GitHub environment
+# variables 

--- a/plugins/metrics/build/plugin.py
+++ b/plugins/metrics/build/plugin.py
@@ -13,6 +13,7 @@ from plugins.metrics.iam_policies import get_policies
 # Keys to pass through from .env to Lambda (if set).
 # config.py has its own defaults for each.
 _METRICS_ENV_KEYS = [
+    "METRICS_CROSS_ACCOUNT_ROLE_ARN",
     "OPENSEARCH_REGION", "OPENSEARCH_SERVICE",
     "OPENSEARCH_INTEGRATION_TEST_INDEX", "OPENSEARCH_BUILD_RESULTS_INDEX",
     "OPENSEARCH_RELEASE_METRICS_INDEX",

--- a/plugins/metrics/iam_policies.py
+++ b/plugins/metrics/iam_policies.py
@@ -3,12 +3,13 @@
 
 """Shared IAM policies for all metrics plugins."""
 
-from typing import List, Optional
+import os
+from typing import List
 
 from aws_cdk import aws_iam as iam
 
 
-def get_policies(account_id: str, region: str, env: str, metrics_account_role: Optional[str] = None) -> List[iam.PolicyStatement]:
+def get_policies(account_id: str, region: str, env: str) -> List[iam.PolicyStatement]:
     policies = [
         iam.PolicyStatement(
             sid="VPCEndpointAccess",
@@ -17,6 +18,7 @@ def get_policies(account_id: str, region: str, env: str, metrics_account_role: O
             resources=[f"arn:aws:s3:::oscar-metrics-cache-{account_id}/*"],
         ),
     ]
+    metrics_account_role = os.environ.get("METRICS_CROSS_ACCOUNT_ROLE_ARN")
     if metrics_account_role:
         policies.append(
             iam.PolicyStatement(

--- a/plugins/metrics/lambda/config.py
+++ b/plugins/metrics/lambda/config.py
@@ -40,13 +40,15 @@ class MetricsConfig:
         Raises:
             ValueError: If required environment variables are missing
         """
-        # Load sensitive config from metrics secret
+        # Cross-account role ARN from Lambda env var (set by CDK from .env)
+        self.metrics_cross_account_role_arn = os.environ.get('METRICS_CROSS_ACCOUNT_ROLE_ARN', '')
+
+        # Load remaining sensitive config from metrics secret
         secrets = self._load_from_metrics_secret()
-        self.metrics_cross_account_role_arn = secrets.get('METRICS_CROSS_ACCOUNT_ROLE_ARN', '')
         self.opensearch_host = secrets.get('OPENSEARCH_HOST', '')
 
         if validate_required and not self.metrics_cross_account_role_arn:
-            raise ValueError("METRICS_CROSS_ACCOUNT_ROLE_ARN not found in metrics secret")
+            raise ValueError("METRICS_CROSS_ACCOUNT_ROLE_ARN environment variable is not set")
         if validate_required and not self.opensearch_host:
             raise ValueError("OPENSEARCH_HOST not found in metrics secret")
 
@@ -86,7 +88,6 @@ class MetricsConfig:
         Returns only the keys we need. Does NOT inject anything into os.environ.
         """
         keys_to_extract = {
-            'METRICS_CROSS_ACCOUNT_ROLE_ARN',
             'OPENSEARCH_HOST',
         }
         result: Dict[str, str] = {}

--- a/plugins/metrics/lambda/helper_functions.py
+++ b/plugins/metrics/lambda/helper_functions.py
@@ -44,7 +44,7 @@ def resolve_components_from_build_numbers(version: str, build_numbers: List[str]
         }
     }
 
-    result = opensearch_request('POST', f'/{config.get_build_results_index_pattern()}/_search', query_body)
+    result = opensearch_request('GET', f'/{config.get_build_results_index_pattern()}/_search', query_body)
 
     build_component_map = {}
     for hit in result.get('hits', {}).get('hits', []):
@@ -93,7 +93,7 @@ def get_rc_distribution_build_number(version: str, rc_number: int, component_nam
         )
 
     # Query all monthly indices to get complete dataset
-    result = opensearch_request('POST', f'/{config.get_integration_test_index_pattern()}/_search', query_body)
+    result = opensearch_request('GET', f'/{config.get_integration_test_index_pattern()}/_search', query_body)
     hits = result.get('hits', {}).get('hits', [])
 
     if not hits:

--- a/plugins/metrics/lambda/query_builders.py
+++ b/plugins/metrics/lambda/query_builders.py
@@ -155,7 +155,7 @@ def query_integration_test_results(
 
     # Execute the main query
     logger.info("INTEGRATION_QUERY: About to execute OpenSearch request")
-    result = opensearch_request('POST', f'/{config.get_integration_test_index_pattern()}/_search', query_body)
+    result = opensearch_request('GET', f'/{config.get_integration_test_index_pattern()}/_search', query_body)
     logger.info("INTEGRATION_QUERY: OpenSearch request completed")
 
     if result and 'hits' in result:
@@ -232,7 +232,7 @@ def query_distribution_build_results(
     # NOTE: status_filter is NOT applied at OpenSearch level to ensure proper deduplication
     # It will be applied after deduplication in the main handler
 
-    return opensearch_request('POST', f'/{config.get_build_results_index_pattern()}/_search', query_body)
+    return opensearch_request('GET', f'/{config.get_build_results_index_pattern()}/_search', query_body)
 
 
 def query_release_readiness(version: str, components: Optional[List[str]] = None) -> Dict[str, Any]:
@@ -276,4 +276,4 @@ def query_release_readiness(version: str, components: Optional[List[str]] = None
                 }
             })
 
-    return opensearch_request('POST', f'/{config.release_metrics_index}/_search', query_body)
+    return opensearch_request('GET', f'/{config.release_metrics_index}/_search', query_body)

--- a/stacks/permissions_stack.py
+++ b/stacks/permissions_stack.py
@@ -91,23 +91,34 @@ class OscarPermissionsStack(Stack):
         return roles
 
     def _create_plugin_roles(self, plugins) -> Dict[str, iam.Role]:
-        """Create one IAM role per plugin from plugin-defined policies."""
+        """Create IAM roles for plugins, deduplicating by Lambda entry path.
+
+        Plugins sharing the same Lambda entry directory share a single role.
+        """
         roles = {}
+        created_entries: Dict[str, iam.Role] = {}
+
         for plugin in plugins:
-            construct_id = f"{plugin.name.replace('-', ' ').title().replace(' ', '')}LambdaRole"
+            entry = plugin.get_lambda_config().entry
+            if entry in created_entries:
+                roles[plugin.name] = created_entries[entry]
+                continue
+
+            role_prefix = entry.split("/")[1].title()  # e.g. "plugins/metrics/lambda" → "Metrics"
             managed = [
                 iam.ManagedPolicy.from_aws_managed_policy_name(p)
                 for p in plugin.get_managed_policies()
             ]
             role = iam.Role(
-                self, construct_id,
+                self, f"{role_prefix}LambdaRole",
                 assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
                 managed_policies=managed,
-                description=f"Execution role for OSCAR {plugin.name} Lambda"
+                description=f"Execution role for OSCAR {role_prefix.lower()} Lambda"
             )
             for stmt in plugin.get_iam_policies(self.account_id, self.aws_region, self.env_name):
                 role.add_to_policy(stmt)
             roles[plugin.name] = role
+            created_entries[entry] = role
         return roles
 
     def _create_api_gateway_role(self) -> iam.Role:

--- a/tests/stacks/test_permissions_stack.py
+++ b/tests/stacks/test_permissions_stack.py
@@ -68,18 +68,13 @@ class TestOscarPermissionsStack:
         })
 
     def test_plugin_roles_creation(self, template):
-        """Test that plugin Lambda roles are created."""
+        """Test that plugin Lambda roles are created (deduplicated by entry path)."""
         template.has_resource_properties("AWS::IAM::Role", {
             "Description": "Execution role for OSCAR jenkins Lambda",
         })
+        # All metrics plugins share the same Lambda entry, so they share one role
         template.has_resource_properties("AWS::IAM::Role", {
-            "Description": "Execution role for OSCAR metrics-build Lambda",
-        })
-        template.has_resource_properties("AWS::IAM::Role", {
-            "Description": "Execution role for OSCAR metrics-test Lambda",
-        })
-        template.has_resource_properties("AWS::IAM::Role", {
-            "Description": "Execution role for OSCAR metrics-release Lambda",
+            "Description": "Execution role for OSCAR metrics Lambda",
         })
 
     def test_api_gateway_role_creation(self, template):


### PR DESCRIPTION
### Description

* Plugins sharing the same Lambda entry path now share a single IAM role instead of creating duplicates
* METRICS_CROSS_ACCOUNT_ROLE_ARN moved from Secrets Manager to .env since it's needed at CDK synth time for IAM policy creation, which can't access Secrets Manager. get_policies() now reads it directly from os.environ instead of accepting it as an optional parameter
* OpenSearch _search calls switched from POST to GET


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
