### PR TITLE
Authenticate GitHub calls for jenkins and add log rentention

### DIFF
--- a/agents/jenkins/README.md
+++ b/agents/jenkins/README.md
@@ -94,8 +94,8 @@ These must be set before `cdk deploy`. Set them in your `.env` file or export in
 Add it in `.env`**
 
 ```
-JENKINS_URL=https://build.ci.opensearch.org
-JENKINSFILE_GITHUB_REPO=opensearch-project/opensearch-build
+JENKINS_URL=https://your-jenkins-url
+JENKINSFILE_GITHUB_REPO=you-user-name/your-repo
 JENKINSFILE_GITHUB_BRANCH=main
 JENKINS_VERIFY_SSL=true
 JENKINSFILE_IGNORE_LIST=jenkins/opensearch/benchmark-test.jenkinsfile,jenkins/opensearch/benchmark-pull-request.jenkinsfile
@@ -119,23 +119,35 @@ The agent authenticates with Jenkins using an API token stored in AWS Secrets Ma
 
 The CDK stack creates a secret named `oscar-jenkins-api-token-{env}` (e.g., `oscar-jenkins-api-token-dev`).
 
-After deployment, populate it with the value in `username:token` format:
+After deployment, populate it with a JSON value containing both the Jenkins API token and a GitHub token:
 
 ```bash
 aws secretsmanager put-secret-value \
   --secret-id oscar-jenkins-api-token-dev \
-  --secret-string "your-jenkins-username:your-api-token"
+  --secret-string '{"jenkins_api_token": "your-username:your-api-token", "github_token": "ghp_your_github_token"}'
 ```
 
 The Lambda reads this secret at startup via the `JENKINS_SECRET_NAME` environment variable (automatically set by CDK).
 
-### Token format
+### Secret format
 
-```
-GithubUsername:api-token
+```json
+{
+  "jenkins_api_token": "username:api-token",
+  "github_token": "ghp_xxxxxxxxxxxx"
+}
 ```
 
-Example: `foo:11a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6`
+| Key | Description | Required |
+|-----|-------------|----------|
+| `jenkins_api_token` | Jenkins credentials in `username:token` format | Yes |
+| `github_token` | GitHub personal access token for Jenkinsfile discovery | No (but strongly recommended — unauthenticated GitHub API is limited to 60 requests/hour) |
+
+### GitHub token setup
+
+1. Go to GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens.
+2. Create a token with **read-only** access to the `Contents` permission on the target repository.
+3. Add it to the secret JSON as `github_token`.
 
 ### Permissions
 

--- a/agents/jenkins/agent.py
+++ b/agents/jenkins/agent.py
@@ -52,7 +52,7 @@ class JenkinsAgent(OscarAgent):
         return [
             SecretConfig(
                 name_suffix="api-token",
-                description="Jenkins and GitHub credentials JSON: {jenkins_api_token, github_token}",
+                description="Jenkins and GitHub credentials in JSON format",
                 env_var="JENKINS_SECRET_NAME",
             ),
         ]

--- a/agents/jenkins/agent.py
+++ b/agents/jenkins/agent.py
@@ -52,7 +52,7 @@ class JenkinsAgent(OscarAgent):
         return [
             SecretConfig(
                 name_suffix="api-token",
-                description="Jenkins API token in username:token format",
+                description="Jenkins and GitHub credentials JSON: {jenkins_api_token, github_token}",
                 env_var="JENKINS_SECRET_NAME",
             ),
         ]

--- a/agents/jenkins/lambda/config.py
+++ b/agents/jenkins/lambda/config.py
@@ -13,6 +13,7 @@ This module provides centralized configuration for the Jenkins integration,
 including job definitions, credentials, and environment settings.
 """
 
+import json
 import logging
 import os
 
@@ -28,8 +29,10 @@ class JenkinsConfig:
     def __init__(self):
         """Initialize configuration by loading .env from secrets manager and setting up all variables."""
 
-        # Load Jenkins API token from dedicated secret
-        self.jenkins_api_token = self._load_jenkins_secret()
+        # Load Jenkins secrets from dedicated secret (JSON format)
+        secrets = self._load_jenkins_secret()
+        self.jenkins_api_token = secrets.get('jenkins_api_token', '')
+        self.github_token = secrets.get('github_token', '')
 
         # Jenkins Server Configuration (required)
         self.jenkins_url = os.environ.get('JENKINS_URL', '')
@@ -48,12 +51,15 @@ class JenkinsConfig:
         # Validate required configuration
         self._validate_config()
 
-    def _load_jenkins_secret(self) -> str:
-        """Load Jenkins API token exclusively from AWS Secrets Manager."""
+    def _load_jenkins_secret(self) -> dict:
+        """Load Jenkins secrets from AWS Secrets Manager (JSON format).
+
+        Expected format: {"jenkins_api_token": "user:token", "github_token": "ghp_..."}
+        """
         secret_name = os.getenv('JENKINS_SECRET_NAME')
         if not secret_name:
             logger.error("JENKINS_SECRET_NAME environment variable is not set")
-            return ''
+            return {}
 
         try:
             session = boto3.session.Session()
@@ -62,11 +68,12 @@ class JenkinsConfig:
                 region_name=os.getenv('AWS_REGION', 'us-east-1')
             )
             response = client.get_secret_value(SecretId=secret_name)
-            logger.info(f"Loaded Jenkins API token from secret: {secret_name}")
-            return response['SecretString']
+            secret_data = json.loads(response['SecretString'])
+            logger.info(f"Loaded Jenkins secrets from: {secret_name}")
+            return secret_data
         except Exception as e:
             logger.error(f"Failed to load Jenkins secret '{secret_name}': {e}")
-            return ''
+            return {}
 
     def _validate_config(self) -> None:
         """Validate that required configuration is present."""

--- a/agents/jenkins/lambda/jenkinsfile_fetcher.py
+++ b/agents/jenkins/lambda/jenkinsfile_fetcher.py
@@ -25,6 +25,14 @@ FETCH_TIMEOUT = 5
 CACHE_TTL = 3600
 
 
+def _github_headers() -> dict:
+    """Build HTTP headers for GitHub API requests, with auth if configured."""
+    headers = {}
+    if config.github_token:
+        headers["Authorization"] = f"Bearer {config.github_token}"
+    return headers
+
+
 def _is_ignored(path: str) -> bool:
     """Check if a path matches any entry in the ignore list (exact or prefix)."""
     for ignored in config.jenkinsfile_ignore_list:
@@ -59,7 +67,7 @@ def _discover_jenkinsfiles(directory: str = None) -> List[str]:
         current_dir = dirs_to_visit.pop()
         url = _github_api_url(current_dir)
         try:
-            resp = requests.get(url, timeout=FETCH_TIMEOUT)
+            resp = requests.get(url, timeout=FETCH_TIMEOUT, headers=_github_headers())
             if resp.status_code != 200:
                 logger.error(f"GitHub API returned {resp.status_code} for {url}")
                 continue
@@ -85,7 +93,7 @@ def _fetch_jenkinsfile(path: str) -> Optional[str]:
     """Fetch a single Jenkinsfile from GitHub. Returns content or None on error."""
     url = _build_raw_url(path)
     try:
-        resp = requests.get(url, timeout=FETCH_TIMEOUT)
+        resp = requests.get(url, timeout=FETCH_TIMEOUT, headers=_github_headers())
         if resp.status_code == 200:
             return resp.text
         logger.error(f"GitHub returned {resp.status_code} for {url}")

--- a/stacks/knowledge_base_stack.py
+++ b/stacks/knowledge_base_stack.py
@@ -21,6 +21,7 @@ from aws_cdk import aws_events as events
 from aws_cdk import aws_events_targets as targets
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as lambda_
+from aws_cdk import aws_logs as logs
 from aws_cdk import aws_opensearchserverless as opensearchserverless
 from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_s3_notifications as s3n
@@ -330,6 +331,7 @@ class OscarKnowledgeBaseStack(Stack):
         wait_condition = custom_resources.AwsCustomResource(
             self,
             "WaitForCollection",
+            log_retention=logs.RetentionDays.TWO_WEEKS,
             on_create=custom_resources.AwsSdkCall(
                 service="OpenSearchServerless",
                 action="listCollections",
@@ -396,6 +398,7 @@ class OscarKnowledgeBaseStack(Stack):
         index_wait_condition = custom_resources.AwsCustomResource(
             self,
             "WaitForIndex",
+            log_retention=logs.RetentionDays.TWO_WEEKS,
             on_create=custom_resources.AwsSdkCall(
                 service="OpenSearchServerless",
                 action="batchGetCollection",  # Use batchGetCollection instead

--- a/tests/stacks/test_secrets_stack.py
+++ b/tests/stacks/test_secrets_stack.py
@@ -53,7 +53,7 @@ class TestSecretsStack:
         """Jenkins agent's api-token secret should be created."""
         template_with_agents.has_resource_properties("AWS::SecretsManager::Secret", {
             "Name": "oscar-jenkins-api-token-dev",
-            "Description": "Jenkins and GitHub credentials JSON: {jenkins_api_token, github_token}",
+            "Description": "Jenkins and GitHub credentials in JSON format",
         })
 
     def test_two_secrets_with_jenkins_agent(self, template_with_agents):

--- a/tests/stacks/test_secrets_stack.py
+++ b/tests/stacks/test_secrets_stack.py
@@ -53,7 +53,7 @@ class TestSecretsStack:
         """Jenkins agent's api-token secret should be created."""
         template_with_agents.has_resource_properties("AWS::SecretsManager::Secret", {
             "Name": "oscar-jenkins-api-token-dev",
-            "Description": "Jenkins API token in username:token format",
+            "Description": "Jenkins and GitHub credentials JSON: {jenkins_api_token, github_token}",
         })
 
     def test_two_secrets_with_jenkins_agent(self, template_with_agents):


### PR DESCRIPTION
### Description
Authenticate GitHub calls for jenkins to avoid GitHub timeout issues due to API limits. 
Adds log retention of 2 weeks for custom lambdas.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
