### PR TITLE
Increase supervisor agent timeout threshold from 120s to 180s

### DIFF
--- a/lambda/oscar-agent/config.py
+++ b/lambda/oscar-agent/config.py
@@ -88,7 +88,7 @@ class Config:
 
         # Timeout thresholds
         self.hourglass_threshold = int(os.environ.get('HOURGLASS_THRESHOLD_SECONDS', 45))
-        self.timeout_threshold = int(os.environ.get('TIMEOUT_THRESHOLD_SECONDS', 120))
+        self.timeout_threshold = int(os.environ.get('TIMEOUT_THRESHOLD_SECONDS', 180))
 
         # Thread pool settings
         self.max_workers = int(os.environ.get('MAX_WORKERS', 100))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oscar-ai-bot"
-version = "3.0.0"
+version = "3.1.0"
 
 [tool.isort]
 skip_glob = ["cdk.out/*", ".venv/*"]


### PR DESCRIPTION
### Description
Increase supervisor agent timeout threshold from 120s to 180s to allow more time for agentic search queries

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
