### PR TITLE
Add resolved index logging, non-retryable error handling, and memory_id support for metrics agent

### DIFF
--- a/agents/metrics/action_groups.py
+++ b/agents/metrics/action_groups.py
@@ -31,6 +31,11 @@ def get_action_groups(lambda_arn: str) -> List[bedrock.CfnAgent.AgentActionGroup
                                 description="OpenSearch version to scope the query (e.g., '3.2.0', '2.18.0')",
                                 required=True,
                             ),
+                            "memory_id": bedrock.CfnAgent.ParameterDetailProperty(
+                                type="string",
+                                description="Memory ID from a previous query_metrics response. Pass this to maintain conversational context with the search agent across follow-up queries.",
+                                required=False,
+                            ),
                         },
                     ),
                 ]

--- a/agents/metrics/instructions.py
+++ b/agents/metrics/instructions.py
@@ -44,6 +44,9 @@ RESPONSE GUIDELINES:
 - Suggest actionable next steps based on observations
 - Tailor your analysis to what the user is specifically asking for
 
+CONVERSATIONAL CONTEXT:
+When you call query_metrics and the response includes a "memory_id" field, you MUST pass that memory_id back on your next query_metrics call. This gives the search agent context about previous queries so it can handle follow-up questions like "now show me the arm64 results" or "filter to just the failed ones" without needing to repeat the full context. Always check the previous query_metrics response for memory_id and include it in follow-up calls.
+
 Remember: You receive raw metrics data - use your intelligence to interpret and summarize it meaningfully based on the user's query.
 """
 

--- a/agents/metrics/lambda/agentic_search.py
+++ b/agents/metrics/lambda/agentic_search.py
@@ -80,7 +80,7 @@ def enhance_query(query: str, version: str, filters: Optional[Dict[str, Any]] = 
     return enhanced
 
 
-def agentic_search(pipeline: str, query_text: str) -> Dict[str, Any]:
+def agentic_search(pipeline: str, query_text: str, memory_id: Optional[str] = None) -> Dict[str, Any]:
     """Send agentic search request to OpenSearch.
 
     Sends a GET to /_search?search_pipeline={pipeline} with the agentic
@@ -90,6 +90,7 @@ def agentic_search(pipeline: str, query_text: str) -> Dict[str, Any]:
     Args:
         pipeline: Agentic pipeline name (e.g., 'metrics-agentic-pipeline')
         query_text: Enhanced natural language query
+        memory_id: Optional memory ID for conversational context continuity
 
     Returns:
         Raw OpenSearch response dict
@@ -108,17 +109,35 @@ def agentic_search(pipeline: str, query_text: str) -> Dict[str, Any]:
         }
     }
 
+    # Include memory_id for conversational context if provided
+    if memory_id:
+        body["query"]["agentic"]["memory_id"] = memory_id
+        logger.info(f"AGENTIC_SEARCH: Using memory_id={memory_id}")
+
     logger.info(f"AGENTIC_SEARCH: GET {path}")
     logger.info(f"AGENTIC_SEARCH: query_text='{query_text}'")
 
     try:
         result = opensearch_request('GET', path, body)
     except Exception as e:
-        raise AgenticSearchError(f"Agentic search request failed: {e}")
+        error_msg = str(e)
+        # Extract status code from error message if present
+        status_code = None
+        if 'OpenSearch request failed:' in error_msg:
+            try:
+                status_code = int(error_msg.split('OpenSearch request failed:')[1].strip().split(' ')[0])
+            except (ValueError, IndexError):
+                pass
+        raise AgenticSearchError(f"Agentic search request failed: {e}", status_code=status_code)
 
     # Log generated DSL if present
     dsl_query = result.get('ext', {}).get('dsl_query')
     if dsl_query:
         logger.info(f"AGENTIC_SEARCH: Generated DSL: {json.dumps(dsl_query)}")
+
+    # Return memory_id from response if present (for future calls)
+    response_memory_id = result.get('ext', {}).get('memory_id')
+    if response_memory_id:
+        logger.info(f"AGENTIC_SEARCH: Response memory_id={response_memory_id}")
 
     return result

--- a/agents/metrics/lambda/metrics_handler.py
+++ b/agents/metrics/lambda/metrics_handler.py
@@ -103,15 +103,20 @@ def handle_metrics_query(params: Dict[str, Any], request_id: Optional[str] = Non
         logger.info(f"METRICS_QUERY [{req_id}]: Enhanced query='{enhanced_query}'")
 
         # Step 2: Execute agentic search (conversational agent handles index routing)
+        memory_id = params.get('memory_id')
         try:
-            opensearch_results = agentic_search(pipeline_name, enhanced_query)
+            opensearch_results = agentic_search(pipeline_name, enhanced_query, memory_id=memory_id)
             logger.info(f"METRICS_QUERY [{req_id}]: Agentic search completed")
         except AgenticSearchError as e:
-            logger.error(f"AGENTIC_SEARCH_FAILED: Agentic search failed for request {req_id}: {e}")
+            logger.error(f"AGENTIC_SEARCH_FAILED [{req_id}]: {e}")
+            # Return a clear non-retryable error so Bedrock agent stops retrying
             return {
                 'error': str(e),
                 'status_code': e.status_code,
-                'type': 'agentic_search_error'
+                'type': 'agentic_search_error',
+                'retryable': False,
+                'message': 'The search agent could not generate a valid query. '
+                           'Try rephrasing or simplifying the question. Do not retry this exact query.'
             }
 
         # Step 3: Validate response structure
@@ -130,6 +135,9 @@ def handle_metrics_query(params: Dict[str, Any], request_id: Optional[str] = Non
         raw_hits = opensearch_results.get('hits', {}).get('hits', [])
         if raw_hits:
             first_hit_index = raw_hits[0].get('_index', '')
+            logger.info(f"METRICS_QUERY [{req_id}]: Resolved index: {first_hit_index}")
+        else:
+            logger.info(f"METRICS_QUERY [{req_id}]: Resolved index: none (empty result set)")
 
         if 'integration-test' in first_hit_index:
             results = extract_test_results(opensearch_results)
@@ -151,6 +159,12 @@ def handle_metrics_query(params: Dict[str, Any], request_id: Optional[str] = Non
 
         logger.info(f"METRICS_QUERY [{req_id}]: Extracted {len(results)} results")
 
+        # Log failed components for quick diagnosis
+        failed = [r.get('component', 'unknown') for r in results
+                  if r.get('component_build_result') == 'failed' or r.get('status') == 'failed']
+        if failed:
+            logger.warning(f"METRICS_QUERY [{req_id}]: {len(failed)} failures: {failed}")
+
         # Build response
         response = {
             'version': version,
@@ -163,6 +177,11 @@ def handle_metrics_query(params: Dict[str, Any], request_id: Optional[str] = Non
         # Include generated DSL when available
         if generated_dsl:
             response['generated_dsl'] = generated_dsl
+
+        # Include memory_id for conversational context continuity
+        response_memory_id = opensearch_results.get('ext', {}).get('memory_id')
+        if response_memory_id:
+            response['memory_id'] = response_memory_id
 
         logger.info(f"METRICS_QUERY [{req_id}]: Returning response with {len(results)} results")
         return response


### PR DESCRIPTION
### Description
Improves the metrics agent's observability, error handling, and conversational context support for agentic search queries.

### Changes
**Resolved index logging**

* Logs which OpenSearch index the agentic search resolved to 
* Logs none (empty result set) when no hits are returned
* Logs failed component names for quick diagnosis when build/test failures are present

**Non-retryable error handling**

* Agentic search errors now return retryable: False with a clear message telling the Bedrock agent to stop retrying the same failing query
* Prevents the Bedrock agent from burning the full Lambda timeout on repeated failures (previously 3-4 retries × 30s each = 120s timeout)

**Conversational memory_id support**

* Passes memory_id from OpenSearch agentic search responses back to the Bedrock agent
* Accepts memory_id as an optional action group parameter so the Bedrock agent can send it on follow-up queries
* Places memory_id inside body["query"]["agentic"]["memory_id"] per the OpenSearch agentic search API spec
* Agent instruction updated to tell the Metrics-Specialist to pass memory_id on follow-up calls


### Issues Resolved
#21 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
