### PR TITLE
Add @shreyah93 as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @getsaurabh02 @peterzhuamazon @gaiksaya @DivyamSengar
+* @getsaurabh02 @peterzhuamazon @gaiksaya @DivyamSengar @shreyah963

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,10 +4,11 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer            | GitHub ID                                           | Affiliation |
-|-----------------------|-----------------------------------------------------|-------------|
-| Peter Zhu             | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon      |
-| Divyam Sengar         | [DivyamSengar](https://github.com/DivyamSengar)     | Community   |
-| Saurabh Singh         | [getsaurabh02](https://github.com/getsaurabh02)     | Amazon      |
-| Sayali Gaikawad       | [gaiksaya](https://github.com/gaiksaya)             | Amazon      |
+| Maintainer      | GitHub ID                                          | Affiliation |
+|-----------------|----------------------------------------------------|-------------|
+| Peter Zhu       | [peterzhuamazon](https://github.com/peterzhuamazon)| Amazon      |
+| Divyam Sengar   | [DivyamSengar](https://github.com/DivyamSengar)    | Community   |
+| Saurabh Singh   | [getsaurabh02](https://github.com/getsaurabh02)    | Amazon      |
+| Sayali Gaikawad | [gaiksaya](https://github.com/gaiksaya)            | Amazon      |
+| Shreya Bhatta   | [shreyah963](https://github.com/shreyah963)        | Amazon      |
 


### PR DESCRIPTION
### Description
Add @shreyah93 as a maintainer

Shreya has contributed some core features for oscar such as agentic search capabilities for metrics, that helped in reducing a huge maintenance overhead of opensearch queries. Currently, she is  working on an entirely new GitHub Agent to be on-boarded to oscar that would take care of GitHub related chores. 

Reference PRs:
https://github.com/opensearch-project/oscar-ai-bot/pull/56
https://github.com/opensearch-project/oscar-ai-bot/pull/75 
https://github.com/opensearch-project/oscar-ai-bot/pull/105
https://github.com/opensearch-project/oscar-ai-bot/pull/114
https://github.com/opensearch-project/oscar-ai-bot/pull/74
https://github.com/opensearch-project/oscar-ai-bot/pull/120

Along with the contributions, Shreya has also helped in reviewing others’ contribution. Checkout the PRs below:
https://github.com/opensearch-project/oscar-ai-bot/pull/111
https://github.com/opensearch-project/oscar-ai-bot/pull/108
https://github.com/opensearch-project/oscar-ai-bot/pull/90

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
