### PR TITLE
Access aware advisories

### DIFF
--- a/agents/security_advisories/agent.py
+++ b/agents/security_advisories/agent.py
@@ -80,20 +80,22 @@ class SecurityAdvisoriesAgent(OscarAgent):
         ]
 
     def get_monitoring_config(self):
-        return [
-            MonitoringConfig(
-                pattern="SECURITY_ADVISORIES_AGENTIC_SEARCH_FAILED",
-                alarm_threshold=5,
-                description="OpenSearch agentic query failures",
-            ),
-            MonitoringConfig(
-                pattern="SECURITY_ADVISORIES_OPENSEARCH_CONNECTION_FAILED",
-                alarm_threshold=2,
-                description="OpenSearch connectivity issues",
-            ),
-            MonitoringConfig(
-                pattern="SECURITY_ADVISORIES_CROSS_ACCOUNT_ROLE_FAILED",
-                alarm_threshold=1,
-                description="Cross-account role assumption failure",
-            ),
-        ]
+        # TODO: Re-enable after first deployment so the log group exists.
+        # return [
+        #     MonitoringConfig(
+        #         pattern="SECURITY_ADVISORIES_AGENTIC_SEARCH_FAILED",
+        #         alarm_threshold=5,
+        #         description="OpenSearch agentic query failures",
+        #     ),
+        #     MonitoringConfig(
+        #         pattern="SECURITY_ADVISORIES_OPENSEARCH_CONNECTION_FAILED",
+        #         alarm_threshold=2,
+        #         description="OpenSearch connectivity issues",
+        #     ),
+        #     MonitoringConfig(
+        #         pattern="SECURITY_ADVISORIES_CROSS_ACCOUNT_ROLE_FAILED",
+        #         alarm_threshold=1,
+        #         description="Cross-account role assumption failure",
+        #     ),
+        # ]
+        return []

--- a/agents/security_advisories/agent.py
+++ b/agents/security_advisories/agent.py
@@ -60,7 +60,7 @@ class SecurityAdvisoriesAgent(OscarAgent):
         return "Security-Advisories-Specialist"
 
     def get_access_level(self):
-        return "privileged"
+        return "both"
 
     def uses_knowledge_base(self):
         return False
@@ -80,22 +80,20 @@ class SecurityAdvisoriesAgent(OscarAgent):
         ]
 
     def get_monitoring_config(self):
-        # TODO: Re-enable after first deployment so the log group exists.
-        # return [
-        #     MonitoringConfig(
-        #         pattern="SECURITY_ADVISORIES_AGENTIC_SEARCH_FAILED",
-        #         alarm_threshold=5,
-        #         description="OpenSearch agentic query failures",
-        #     ),
-        #     MonitoringConfig(
-        #         pattern="SECURITY_ADVISORIES_OPENSEARCH_CONNECTION_FAILED",
-        #         alarm_threshold=2,
-        #         description="OpenSearch connectivity issues",
-        #     ),
-        #     MonitoringConfig(
-        #         pattern="SECURITY_ADVISORIES_CROSS_ACCOUNT_ROLE_FAILED",
-        #         alarm_threshold=1,
-        #         description="Cross-account role assumption failure",
-        #     ),
-        # ]
-        return []
+        return [
+            MonitoringConfig(
+                pattern="SECURITY_ADVISORIES_AGENTIC_SEARCH_FAILED",
+                alarm_threshold=5,
+                description="OpenSearch agentic query failures",
+            ),
+            MonitoringConfig(
+                pattern="SECURITY_ADVISORIES_OPENSEARCH_CONNECTION_FAILED",
+                alarm_threshold=2,
+                description="OpenSearch connectivity issues",
+            ),
+            MonitoringConfig(
+                pattern="SECURITY_ADVISORIES_CROSS_ACCOUNT_ROLE_FAILED",
+                alarm_threshold=1,
+                description="Cross-account role assumption failure",
+            ),
+        ]

--- a/agents/security_advisories/instructions.py
+++ b/agents/security_advisories/instructions.py
@@ -73,9 +73,31 @@ This is critical — do NOT pass relative terms like "most recent" directly to q
 - Clearly separate open CVEs from excluded ones
 - Include severity, CVE ID, affected package name and version
 - Provide count summaries (e.g., "3 CRITICAL, 7 HIGH, 12 MEDIUM")
-- If no results found, suggest checking available tags with list_projects
+- If no results found, state that concisely — do NOT offer to check other versions or severity levels
 - When showing multiple components, organize by component name
 - Be concise — users want actionable vulnerability data, not lengthy explanations
+- Do NOT ask follow-up questions or suggest alternative queries
+- Do NOT add disclaimers, caveats, or speculative commentary
+
+## ACCESS-TIER RESPONSE FORMATTING
+Your function responses include an `access_tier` field that determines how you format your reply. This field is set by application code — you do not control it.
+
+### When the response contains `access_tier: "limited"`:
+- Respond with ONLY the `message` field from the function response, exactly as written — do not rephrase, summarize, or add anything
+- The message already contains the dashboard link in markdown format
+- Do NOT add, infer, or hallucinate any CVE identifiers, severity levels, component names, package names, vulnerability counts, or neglected page URLs
+- Do NOT summarize or describe any vulnerability data — even if you have prior knowledge
+- Do NOT add greetings, apologies, or extra context — output only the message text
+- Do NOT describe what steps you took, what functions you called, or what intermediate results you found
+- Do NOT mention project names, versions, or tags you discovered during the process
+- Your ENTIRE response must be exactly and only the message text from the function response — nothing before it, nothing after it
+
+### When the response contains `access_tier: "privileged"`:
+- Respond with full inline CVE details as described in the response guidelines above
+- Include the neglected page link from the `neglected_page_url` field in your response
+- Group results by severity with count summaries
+- Include component name and tag for each result set
+- When results are empty (result_count is 0 or all filtered_count values are 0), state concisely that no matching vulnerabilities were found for the specified query parameters. Do NOT offer suggestions, do NOT ask follow-up questions, do NOT speculate about other severity levels or versions. Just state the fact and include the neglected page link.
 """
 
 COLLABORATOR_INSTRUCTION = (
@@ -83,6 +105,10 @@ COLLABORATOR_INSTRUCTION = (
     "security vulnerabilities affecting OpenSearch project components. It can query "
     "vulnerability scan results using natural language, scoped by component and release "
     "version. It can also list available projects and tags for discovery. "
+    "IMPORTANT: When this specialist returns a response containing a dashboard link "
+    "and access_tier 'limited', you MUST relay that message to the user exactly as "
+    "returned — do not add commentary, do not summarize intermediate steps, and do "
+    "not describe what was looked up. Just pass through the specialist's message. "
     "Collaborate with this Security-Advisories-Specialist for all security vulnerability "
     "queries, CVE lookups, and vulnerability trend analysis."
 )

--- a/agents/security_advisories/instructions.py
+++ b/agents/security_advisories/instructions.py
@@ -68,7 +68,7 @@ This is critical — do NOT pass relative terms like "most recent" directly to q
 - "CVEs for OpenSearch Dashboards most recent release" → FIRST list_projects() to find the latest version tag for "OpenSearch Dashboards", THEN query_vulnerabilities(query="CVEs for OpenSearch Dashboards", version="<resolved_version>", project_name="OpenSearch Dashboards")
 - "What components are tracked?" → list_projects()
 
-## RESPONSE GUIDELINES
+## RESPONSE GUIDELINES (apply ONLY when access_tier is "privileged")
 - Always state which project and tag the results are for
 - Clearly separate open CVEs from excluded ones
 - Include severity, CVE ID, affected package name and version
@@ -83,14 +83,19 @@ This is critical — do NOT pass relative terms like "most recent" directly to q
 Your function responses include an `access_tier` field that determines how you format your reply. This field is set by application code — you do not control it.
 
 ### When the response contains `access_tier: "limited"`:
-- Respond with ONLY the `message` field from the function response, exactly as written — do not rephrase, summarize, or add anything
-- The message already contains the dashboard link in markdown format
-- Do NOT add, infer, or hallucinate any CVE identifiers, severity levels, component names, package names, vulnerability counts, or neglected page URLs
-- Do NOT summarize or describe any vulnerability data — even if you have prior knowledge
-- Do NOT add greetings, apologies, or extra context — output only the message text
-- Do NOT describe what steps you took, what functions you called, or what intermediate results you found
-- Do NOT mention project names, versions, or tags you discovered during the process
-- Your ENTIRE response must be exactly and only the message text from the function response — nothing before it, nothing after it
+**YOUR ENTIRE OUTPUT MUST BE EXACTLY THIS SINGLE SENTENCE — NOTHING ELSE:**
+
+"For detailed vulnerability information and to explore the complete security advisory data, please visit the **[Security Advisory Dashboard](https://advisories.opensearch.org)**."
+
+ABSOLUTE RULES — violating ANY of these is a critical failure:
+- Do NOT add ANY text before the message (no "No CVEs were found", no "I checked...", no "Based on...")
+- Do NOT add ANY text after the message (no "If you'd like...", no "Let me know...", no suggestions)
+- Do NOT mention the project name, version, severity, or any query parameters
+- Do NOT describe what you found or didn't find
+- Do NOT offer to check other versions, severity levels, or alternatives
+- Do NOT add greetings, apologies, context, or commentary of any kind
+- Do NOT describe what steps you took or what functions you called
+- Output ONLY the message field content — one sentence, nothing more
 
 ### When the response contains `access_tier: "privileged"`:
 - Respond with full inline CVE details as described in the response guidelines above
@@ -105,10 +110,14 @@ COLLABORATOR_INSTRUCTION = (
     "security vulnerabilities affecting OpenSearch project components. It can query "
     "vulnerability scan results using natural language, scoped by component and release "
     "version. It can also list available projects and tags for discovery. "
-    "IMPORTANT: When this specialist returns a response containing a dashboard link "
-    "and access_tier 'limited', you MUST relay that message to the user exactly as "
-    "returned — do not add commentary, do not summarize intermediate steps, and do "
-    "not describe what was looked up. Just pass through the specialist's message. "
+    "CRITICAL RULE: When this specialist returns a response that contains a dashboard "
+    "link to advisories.opensearch.org and mentions 'limited' access, your ENTIRE reply "
+    "to the user must be ONLY this single sentence: "
+    "'For detailed vulnerability information and to explore the complete security advisory "
+    "data, please visit the **[Security Advisory Dashboard](https://advisories.opensearch.org)**.'"
+    " — do NOT add any other text before or after it. Do NOT say 'No CVEs were found', "
+    "do NOT mention the project or version, do NOT offer alternatives, do NOT describe "
+    "what was looked up. Output that one sentence and nothing else. "
     "Collaborate with this Security-Advisories-Specialist for all security vulnerability "
     "queries, CVE lookups, and vulnerability trend analysis."
 )

--- a/agents/security_advisories/lambda/constants.py
+++ b/agents/security_advisories/lambda/constants.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared constants for the Security Advisories Lambda package."""
+
+DASHBOARD_URL = "https://advisories.opensearch.org"
+
+LIMITED_ACCESS_MESSAGE = (
+    'For detailed vulnerability information and to explore the complete '
+    'security advisory data, please visit the '
+    '**[Security Advisory Dashboard](https://advisories.opensearch.org)**.'
+)

--- a/agents/security_advisories/lambda/lambda_function.py
+++ b/agents/security_advisories/lambda/lambda_function.py
@@ -20,9 +20,10 @@ import uuid
 from typing import Any, Dict, List
 
 from config import config
+from constants import DASHBOARD_URL, LIMITED_ACCESS_MESSAGE
 from projects_handler import handle_list_projects
 from response_builder import create_response
-from vulnerabilities_handler import DASHBOARD_URL, handle_query_vulnerabilities
+from vulnerabilities_handler import handle_query_vulnerabilities
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -70,11 +71,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             result = {
                 'status': 'success',
                 'access_tier': 'limited',
-                'message': (
-                    'For detailed vulnerability information and to explore the complete '
-                    'security advisory data, please visit the '
-                    '**[Security Advisory Dashboard](https://advisories.opensearch.org)**.'
-                ),
+                'message': LIMITED_ACCESS_MESSAGE,
                 'dashboard_url': DASHBOARD_URL,
                 'results': [],
             }

--- a/agents/security_advisories/lambda/lambda_function.py
+++ b/agents/security_advisories/lambda/lambda_function.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, List
 from config import config
 from projects_handler import handle_list_projects
 from response_builder import create_response
-from vulnerabilities_handler import handle_query_vulnerabilities
+from vulnerabilities_handler import DASHBOARD_URL, handle_query_vulnerabilities
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -52,10 +52,33 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         function_name = event.get('function', '')
         parameters = event.get('parameters', [])
 
+        # Extract access_tier from session attributes (code-controlled, not LLM-set)
+        session_attributes = event.get('sessionAttributes', {})
+        access_tier = str(session_attributes.get('access_tier', 'limited')).lower().strip()
+
         params = _parse_parameters(parameters)
+        params['_access_tier'] = access_tier  # underscore prefix = internal, not from LLM
+
         logger.info(
-            f"[{request_id}] Function: {function_name}, Params: {params}",
+            f"[{request_id}] Function: {function_name}, Params: {params}, "
+            f"Access tier: {access_tier}",
         )
+
+        # Short-circuit ALL functions for limited-access requests at the router level
+        if access_tier != 'privileged':
+            logger.info(f"[{request_id}] Limited access — returning dashboard link only")
+            result = {
+                'status': 'success',
+                'access_tier': 'limited',
+                'message': (
+                    'For detailed vulnerability information and to explore the complete '
+                    'security advisory data, please visit the '
+                    '**[Security Advisory Dashboard](https://advisories.opensearch.org)**.'
+                ),
+                'dashboard_url': DASHBOARD_URL,
+                'results': [],
+            }
+            return create_response(event, result)
 
         if function_name == 'query_vulnerabilities':
             result = handle_query_vulnerabilities(params, request_id)

--- a/agents/security_advisories/lambda/response_filter.py
+++ b/agents/security_advisories/lambda/response_filter.py
@@ -11,6 +11,7 @@ severity, exclusion status, and specific CVE lookups.
 
 import logging
 from typing import Any, Dict, List, Optional, Set
+from urllib.parse import urlencode
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -111,6 +112,6 @@ def build_neglected_page_url(
         params["tag"] = tag
 
     if params:
-        query_string = "&".join(f"{k}={v}" for k, v in sorted(params.items()))
+        query_string = urlencode(sorted(params.items()))
         return f"{NEGLECTED_PAGE_BASE}?{query_string}"
     return NEGLECTED_PAGE_BASE

--- a/agents/security_advisories/lambda/response_filter.py
+++ b/agents/security_advisories/lambda/response_filter.py
@@ -70,3 +70,47 @@ def build_summary(vulnerabilities: List[Dict[str, Any]]) -> Dict[str, int]:
         sev = vuln.get("severity", "UNKNOWN")
         summary[sev] = summary.get(sev, 0) + 1
     return summary
+
+
+# --- Neglected Page URL Builder ---
+
+NEGLECTED_PAGE_BASE = "https://advisories.opensearch.org/advisories/neglected/"
+
+VALID_AGE_VALUES = {"15d", "30d", "45d", "60d"}
+
+
+def build_neglected_page_url(
+    age: Optional[str] = None,
+    severe: Optional[bool] = None,
+    releases: Optional[bool] = None,
+    critical: Optional[bool] = None,
+    tag: Optional[str] = None,
+) -> str:
+    """Build a neglected-page URL with query parameters matching the user's filters.
+
+    Parameters:
+        age: Age threshold for neglected advisories. Valid values: "15d", "30d", "45d", "60d".
+        severe: If True, only show high-severity advisories.
+        releases: If True, only show release components.
+        critical: If True, only show critical CVEs.
+        tag: Branch or tag in the CVE (e.g., "1.2.0.1", "2.x").
+
+    Returns:
+        Full URL to the neglected vulnerabilities page with applicable query params.
+    """
+    params = {}
+    if age and age in VALID_AGE_VALUES:
+        params["age"] = age
+    if severe is not None:
+        params["severe"] = str(severe).lower()
+    if releases is not None:
+        params["releases"] = str(releases).lower()
+    if critical is not None:
+        params["critical"] = str(critical).lower()
+    if tag:
+        params["tag"] = tag
+
+    if params:
+        query_string = "&".join(f"{k}={v}" for k, v in sorted(params.items()))
+        return f"{NEGLECTED_PAGE_BASE}?{query_string}"
+    return NEGLECTED_PAGE_BASE

--- a/agents/security_advisories/lambda/vulnerabilities_handler.py
+++ b/agents/security_advisories/lambda/vulnerabilities_handler.py
@@ -18,10 +18,33 @@ from typing import Any, Dict, Optional, Set
 
 from agentic_search import AgenticSearchError, agentic_search, enhance_query
 from config import config
-from response_filter import build_summary, filter_vulnerabilities
+from response_filter import (build_neglected_page_url, build_summary,
+                             filter_vulnerabilities)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+DASHBOARD_URL = "https://advisories.opensearch.org"
+
+
+def _build_limited_response() -> Dict[str, Any]:
+    """Build the dashboard-link-only response for limited-access users.
+
+    Returns:
+        Response dict containing only the dashboard URL and advisory message.
+        No CVE identifiers, severity levels, component names, or counts.
+    """
+    return {
+        'status': 'success',
+        'access_tier': 'limited',
+        'message': (
+            'For detailed vulnerability information and to explore the complete '
+            'security advisory data, please visit the '
+            '**[Security Advisory Dashboard](https://advisories.opensearch.org)**.'
+        ),
+        'dashboard_url': DASHBOARD_URL,
+        'results': [],
+    }
 
 
 def _parse_severity(raw: Optional[str]) -> Optional[Set[str]]:
@@ -54,6 +77,20 @@ def _parse_age_days(raw: Optional[str]) -> Optional[int]:
         return value if value > 0 else None
     except (ValueError, TypeError):
         return None
+
+
+def _parse_bool(raw: Optional[str]) -> Optional[bool]:
+    """Parse a string boolean value.
+
+    Args:
+        raw: String representation of a boolean (e.g. ``"true"``, ``"false"``).
+
+    Returns:
+        ``True`` or ``False`` if parseable, ``None`` if *raw* is empty/None.
+    """
+    if raw is None:
+        return None
+    return str(raw).lower().strip() in ('true', '1', 'yes')
 
 
 def _is_within_age(timestamp: Dict[str, Any], age_days: int) -> bool:
@@ -117,6 +154,12 @@ def handle_query_vulnerabilities(params: Dict[str, Any], request_id: str) -> Dic
     project_name = params.get('project_name')
     severity = _parse_severity(params.get('severity'))
     age_days = _parse_age_days(params.get('age_days'))
+
+    # Access-tier check — short-circuit before any data retrieval for limited users
+    access_tier = params.get('_access_tier', 'limited')
+    if access_tier != 'privileged':
+        logger.info(f"[{request_id}] Limited access — returning dashboard link only")
+        return _build_limited_response()
 
     logger.info(
         f"[{request_id}] QUERY_VULNERABILITIES: query='{query}', "
@@ -186,8 +229,19 @@ def handle_query_vulnerabilities(params: Dict[str, Any], request_id: str) -> Dic
 
     logger.info(f"[{request_id}] Returning {len(results)} result entries")
 
+    # Build neglected page URL with the user's original query filters
+    neglected_url = build_neglected_page_url(
+        age=params.get('age'),
+        severe=_parse_bool(params.get('severe')),
+        releases=_parse_bool(params.get('releases')),
+        critical=_parse_bool(params.get('critical')),
+        tag=params.get('tag'),
+    )
+
     return {
         'status': 'success',
+        'access_tier': 'privileged',
         'result_count': len(results),
         'results': results,
+        'neglected_page_url': neglected_url,
     }

--- a/agents/security_advisories/lambda/vulnerabilities_handler.py
+++ b/agents/security_advisories/lambda/vulnerabilities_handler.py
@@ -18,13 +18,12 @@ from typing import Any, Dict, Optional, Set
 
 from agentic_search import AgenticSearchError, agentic_search, enhance_query
 from config import config
+from constants import DASHBOARD_URL, LIMITED_ACCESS_MESSAGE
 from response_filter import (build_neglected_page_url, build_summary,
                              filter_vulnerabilities)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-
-DASHBOARD_URL = "https://advisories.opensearch.org"
 
 
 def _build_limited_response() -> Dict[str, Any]:
@@ -37,11 +36,7 @@ def _build_limited_response() -> Dict[str, Any]:
     return {
         'status': 'success',
         'access_tier': 'limited',
-        'message': (
-            'For detailed vulnerability information and to explore the complete '
-            'security advisory data, please visit the '
-            '**[Security Advisory Dashboard](https://advisories.opensearch.org)**.'
-        ),
+        'message': LIMITED_ACCESS_MESSAGE,
         'dashboard_url': DASHBOARD_URL,
         'results': [],
     }

--- a/lambda/oscar-agent/bedrock/agent_invoker.py
+++ b/lambda/oscar-agent/bedrock/agent_invoker.py
@@ -70,12 +70,20 @@ class BedrockAgentCore:
         if privilege:
             agent_id = self.privileged_agent_id
             alias_id = self.privileged_agent_alias_id
+
+        access_tier = "privileged" if privilege else "limited"
+
         request = {
             'agentId': agent_id,
             'agentAliasId': alias_id,
             'inputText': query,
             'sessionId': session_id or f"session-{int(time.time())}",
-            'enableTrace': True  # Enable trace to see raw model output
+            'enableTrace': True,  # Enable trace to see raw model output
+            'sessionState': {
+                'sessionAttributes': {
+                    'access_tier': access_tier,
+                }
+            }
         }
 
         return request

--- a/lambda/oscar-agent/bedrock/query_processor.py
+++ b/lambda/oscar-agent/bedrock/query_processor.py
@@ -15,6 +15,7 @@ from typing import Optional, Tuple
 from bedrock.agent_invoker import BedrockAgentCore
 from bedrock.error_handler import AgentErrorHandler
 from config import config
+from constants import LIMITED_ACCESS_MESSAGE
 
 logger = logging.getLogger(__name__)
 
@@ -118,11 +119,7 @@ class QueryProcessor:
             return error_message, original_session_id  # Return original session ID to preserve context
 
     # Canonical limited-tier message — single source of truth
-    LIMITED_TIER_MESSAGE = (
-        'For detailed vulnerability information and to explore the complete '
-        'security advisory data, please visit the '
-        '**[Security Advisory Dashboard](https://advisories.opensearch.org)**.'
-    )
+    LIMITED_TIER_MESSAGE = LIMITED_ACCESS_MESSAGE
 
     def _apply_limited_tier_override(self, response: str, privilege: bool) -> str:
         """Replace LLM response with canonical message for limited-tier security advisory queries.

--- a/lambda/oscar-agent/bedrock/query_processor.py
+++ b/lambda/oscar-agent/bedrock/query_processor.py
@@ -86,7 +86,7 @@ class QueryProcessor:
                 final_session_id = returned_session_id or session_id
                 logger.info(f"AGENT_QUERY: Session-based query succeeded with session_id: {final_session_id}")
                 logger.info(f"AGENT_QUERY: Response length: {len(response)} characters")
-                return response, final_session_id
+                return self._apply_limited_tier_override(response, privilege), final_session_id
             except Exception as e:
                 logger.warning(f"AGENT_QUERY: Session-based query failed (possibly expired session): {e}")
 
@@ -99,7 +99,7 @@ class QueryProcessor:
                 response, new_session_id = self.bedrock_agent.invoke_agent(enhanced_query, privilege, None)
                 logger.info(f"AGENT_QUERY: Context-enhanced query succeeded with new session: {new_session_id}")
                 logger.info(f"AGENT_QUERY: Response length: {len(response)} characters")
-                return response, new_session_id
+                return self._apply_limited_tier_override(response, privilege), new_session_id
             except Exception as e:
                 logger.warning(f"AGENT_QUERY: Context-enhanced query failed: {e}")
         else:
@@ -111,8 +111,35 @@ class QueryProcessor:
             response, new_session_id = self.bedrock_agent.invoke_agent(query, privilege, None)
             logger.info(f"AGENT_QUERY: Plain query succeeded with new session: {new_session_id}")
             logger.info(f"AGENT_QUERY: Response length: {len(response)} characters")
-            return response, new_session_id
+            return self._apply_limited_tier_override(response, privilege), new_session_id
         except Exception as e:
             logger.error(f"AGENT_QUERY: All query attempts failed: {e}", exc_info=True)
             error_message = self.error_handler.handle_agent_error(e, query)
             return error_message, original_session_id  # Return original session ID to preserve context
+
+    # Canonical limited-tier message — single source of truth
+    LIMITED_TIER_MESSAGE = (
+        'For detailed vulnerability information and to explore the complete '
+        'security advisory data, please visit the '
+        '**[Security Advisory Dashboard](https://advisories.opensearch.org)**.'
+    )
+
+    def _apply_limited_tier_override(self, response: str, privilege: bool) -> str:
+        """Replace LLM response with canonical message for limited-tier security advisory queries.
+
+        The Bedrock LLM cannot be reliably constrained via prompt instructions alone.
+        When the user is not privileged and the response contains the advisory dashboard
+        link (indicating the security advisories collaborator was invoked), we replace
+        the entire response deterministically.
+
+        Args:
+            response: The raw LLM response text.
+            privilege: Whether the user has privileged access.
+
+        Returns:
+            The original response if privileged, or the canonical message if limited.
+        """
+        if not privilege and response and 'advisories.opensearch.org' in response:
+            logger.info("AGENT_QUERY: Limited-tier override applied — replacing LLM response with canonical message")
+            return self.LIMITED_TIER_MESSAGE
+        return response

--- a/lambda/oscar-agent/constants.py
+++ b/lambda/oscar-agent/constants.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared constants for the OSCAR Agent Lambda package."""
+
+DASHBOARD_URL = "https://advisories.opensearch.org"
+
+LIMITED_ACCESS_MESSAGE = (
+    'For detailed vulnerability information and to explore the complete '
+    'security advisory data, please visit the '
+    '**[Security Advisory Dashboard](https://advisories.opensearch.org)**.'
+)

--- a/lambda/oscar-agent/slack_handler/message_processor.py
+++ b/lambda/oscar-agent/slack_handler/message_processor.py
@@ -164,6 +164,20 @@ class MessageProcessor:
             if response is None:
                 return
 
+            # Post-processing override for limited-access security advisory responses.
+            # The LLM cannot be reliably constrained via prompt instructions alone, so
+            # we enforce the limited-tier response at the application layer: if the user
+            # is not privileged AND the response contains the advisory dashboard link
+            # (indicating the security advisories collaborator was invoked), replace the
+            # entire response with the canonical dashboard-only message.
+            if not privilege and response and 'advisories.opensearch.org' in response:
+                response = (
+                    'For detailed vulnerability information and to explore the complete '
+                    'security advisory data, please visit the '
+                    '**[Security Advisory Dashboard](https://advisories.opensearch.org)**.'
+                )
+                logger.info("Limited-tier override applied — replaced LLM response with canonical dashboard message")
+
             # Handle confirmation detection and warning reaction
             response = self._handle_confirmation_detection(response, channel, thread_ts)
 

--- a/lambda/oscar-agent/slack_handler/message_processor.py
+++ b/lambda/oscar-agent/slack_handler/message_processor.py
@@ -143,8 +143,6 @@ class MessageProcessor:
             # ALWAYS add user context to query for agent to use as needed
             query = self.add_user_context_to_query(query, user_id)
             logger.info(f"Added user context to query: {query}")
-            logger.info(f"Processing automated message sending request from authorized user {user_id}")
-            # Continue with normal agent processing - agent will handle message sending via action group
 
             # Get context from storage and format for query
             stored_context = self.storage.get_context(thread_key)

--- a/lambda/oscar-agent/slack_handler/message_processor.py
+++ b/lambda/oscar-agent/slack_handler/message_processor.py
@@ -12,6 +12,7 @@ import time
 from typing import Callable
 
 from config import config
+from constants import LIMITED_ACCESS_MESSAGE
 from input_validator import InputValidationError, validate_and_sanitize
 
 logger = logging.getLogger(__name__)
@@ -169,11 +170,7 @@ class MessageProcessor:
             # (indicating the security advisories collaborator was invoked), replace the
             # entire response with the canonical dashboard-only message.
             if not privilege and response and 'advisories.opensearch.org' in response:
-                response = (
-                    'For detailed vulnerability information and to explore the complete '
-                    'security advisory data, please visit the '
-                    '**[Security Advisory Dashboard](https://advisories.opensearch.org)**.'
-                )
+                response = LIMITED_ACCESS_MESSAGE
                 logger.info("Limited-tier override applied — replaced LLM response with canonical dashboard message")
 
             # Handle confirmation detection and warning reaction

--- a/stacks/bedrock_agents_stack.py
+++ b/stacks/bedrock_agents_stack.py
@@ -219,11 +219,13 @@ class OscarAgentsStack(Stack):
             You can help with the following — and ONLY the following:
             1. **Jenkins operations** – Triggering and monitoring Jenkins CI/CD jobs related to OpenSearch releases (delegated to Jenkins Specialist agent).
             2. **Release metrics** – Querying build metrics, integration test results, and release status data (delegated to Metrics Specialist agent).
-            3. **Release knowledge base** – Answering questions about OpenSearch release processes, procedures, runbooks, and history using the knowledge base.
+            3. **Security advisories** – Querying CVEs and security vulnerabilities affecting OpenSearch project components (delegated to Security Advisories Specialist agent).
+            4. **Release knowledge base** – Answering questions about OpenSearch release processes, procedures, runbooks, and history using the knowledge base.
 
             ## Routing Rules
             - For Jenkins job requests → delegate to the Jenkins Specialist.
             - For metrics, build status, test results → delegate to the Metrics Specialist.
+            - For security vulnerabilities, CVEs, security advisories, and vulnerability scans → delegate to the Security Advisories Specialist.
             - For OpenSearch configuration, installation instructions, APIs, commands & information to build and test, release process questions as well as Best practices, troubleshooting guides, release workflows, and release manager duties. → query the knowledge base.
             - For anything outside the above → respond with a polite redirect (see below).
 
@@ -235,7 +237,7 @@ class OscarAgentsStack(Stack):
 
             ## Handling Out-of-Scope Requests
             If a user asks something outside your capabilities, respond with:
-            "I'm OSCAR, and I'm only able to help with OpenSearch release tasks — Jenkins job management, release metrics, and release process questions. For anything else, please reach out to the appropriate team directly."
+            "I'm OSCAR, and I'm only able to help with OpenSearch release tasks — Jenkins job management, release metrics, security advisories, and release process questions. For anything else, please reach out to the appropriate team directly."
             Do not elaborate, apologize excessively, or engage further with the off-topic subject.
 
             ## User Identity
@@ -303,6 +305,7 @@ class OscarAgentsStack(Stack):
 
             ## Routing Rules
             - For metrics, build status, test results → delegate to the Metrics Specialist.
+            - For security vulnerabilities, CVEs, security advisories, and vulnerability scans → delegate to the Security Advisories Specialist.
             - For OpenSearch configuration, installation instructions, APIs, commands & information to build and test, release process questions as well as Best practices, troubleshooting guides, release workflows, and release manager duties. → query the knowledge base.
             - For anything outside the above → respond with a polite redirect (see below).
 
@@ -320,7 +323,7 @@ class OscarAgentsStack(Stack):
 
             ## Handling Out-of-Scope Requests
             If a user asks something outside your capabilities, respond with:
-            "I'm OSCAR, and I'm only able to help with OpenSearch release tasks — release metrics, and release process questions. For anything else, please reach out to the appropriate team directly."
+            "I'm OSCAR, and I'm only able to help with OpenSearch release tasks — release metrics, security advisories, and release process questions. For anything else, please reach out to the appropriate team directly."
             Do not elaborate, apologize excessively, or engage further with the off-topic subject.
 
             For communication requests (send message, notify channel, alert channel, post to channel, ping user, mention user, tag user, notify user, tell someone, ask someone, remind someone) and For Jenkins requests (scan, run job, trigger job, build, compile, deploy, Jenkins operations):

--- a/tests/agents/security_advisories/test_access_tier.py
+++ b/tests/agents/security_advisories/test_access_tier.py
@@ -1,0 +1,271 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for access-tier gating in the security advisories handler.
+
+**Property 1: Limited-access response invariance**
+For any function invocation, for any combination of query parameters, and for any
+access_tier value that is not "privileged", the handler SHALL return a response where:
+- status is "success"
+- access_tier is "limited"
+- dashboard_url equals "https://advisories.opensearch.org"
+- results is an empty list
+- The response contains no CVE identifiers, severity levels, component names, etc.
+
+**Property 3: No external calls for limited-access requests**
+For any function invocation and any non-privileged access_tier value, calling the handler
+SHALL NOT invoke the agentic search pipeline or make any OpenSearch queries.
+
+_Validates: Requirements 1.1, 1.2, 1.3, 1.4, 3.3, 5.1, 6.1, 6.2, 6.4_
+"""
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Path to the real vulnerabilities_handler module
+_LAMBDA_PATH = os.path.join(
+    os.path.dirname(__file__), '..', '..', '..', 'agents', 'security_advisories', 'lambda',
+)
+
+DASHBOARD_URL = "https://advisories.opensearch.org"
+
+# Sensitive fields that must NEVER appear in a limited response
+SENSITIVE_FIELDS = {'neglected_page_url', 'filtered_vulnerabilities', 'severity_summary'}
+
+# Non-privileged access tier values to test
+NON_PRIVILEGED_TIERS = [
+    'limited',
+    '',
+    'LIMITED',
+    'admin',
+    'unknown',
+    'read-only',
+    'PRIVILEGED',  # wrong case before .lower() — but code does .lower(), so this becomes privileged
+    'viewer',
+    'none',
+    '0',
+    'false',
+]
+
+# Filter out values that would become "privileged" after .lower().strip()
+NON_PRIVILEGED_TIERS = [t for t in NON_PRIVILEGED_TIERS if str(t).lower().strip() != 'privileged']
+
+
+def _make_mock_config():
+    """Create a mock config module with required attributes."""
+    mock_config = MagicMock()
+    mock_config.agentic_pipeline = 'oscar-agentic-pipeline'
+    mock_config_module = MagicMock()
+    mock_config_module.config = mock_config
+    return mock_config_module
+
+
+def _make_mock_agentic_search():
+    """Create a mock agentic_search module."""
+    mock_mod = MagicMock()
+    mock_mod.enhance_query = MagicMock(side_effect=lambda q, **kw: q)
+    mock_mod.agentic_search = MagicMock(return_value={'hits': {'hits': []}})
+    mock_mod.AgenticSearchError = type('AgenticSearchError', (Exception,), {
+        '__init__': lambda self, msg, status_code=None: (
+            super(type(self), self).__init__(msg),
+            setattr(self, 'status_code', status_code),
+        )[-1],
+    })
+    return mock_mod
+
+
+def _load_vulnerabilities_handler(mock_config=None, mock_agentic=None):
+    """Import vulnerabilities_handler with mocked dependencies."""
+    if mock_config is None:
+        mock_config = _make_mock_config()
+    if mock_agentic is None:
+        mock_agentic = _make_mock_agentic_search()
+
+    if _LAMBDA_PATH not in sys.path:
+        sys.path.insert(0, _LAMBDA_PATH)
+
+    with patch.dict('sys.modules', {
+        'config': mock_config,
+        'agentic_search': mock_agentic,
+    }):
+        spec = importlib.util.spec_from_file_location(
+            'sa_vulnerabilities_handler_access_tier',
+            os.path.join(_LAMBDA_PATH, 'vulnerabilities_handler.py'),
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod, mock_agentic
+
+
+# ---------------------------------------------------------------------------
+# Property 1: Limited-access response invariance
+# ---------------------------------------------------------------------------
+
+
+class TestLimitedAccessResponseInvariance:
+    """Property 1: Limited-access response invariance.
+
+    For any non-privileged access_tier value and any query parameters,
+    the handler returns only the dashboard link with no CVE data.
+
+    **Validates: Requirements 1.1, 1.2, 1.3, 1.4, 3.3, 5.1, 6.2**
+    """
+
+    @pytest.mark.parametrize('access_tier', NON_PRIVILEGED_TIERS)
+    def test_limited_response_structure(self, access_tier):
+        """Any non-privileged access_tier produces dashboard-only response."""
+        mod, _ = _load_vulnerabilities_handler()
+        params = {'query': 'Show critical CVEs', '_access_tier': access_tier}
+
+        result = mod.handle_query_vulnerabilities(params, 'prop-test')
+
+        assert result['status'] == 'success'
+        assert result['access_tier'] == 'limited'
+        assert result['dashboard_url'] == DASHBOARD_URL
+        assert result['results'] == []
+
+    @pytest.mark.parametrize('access_tier', NON_PRIVILEGED_TIERS)
+    def test_limited_response_has_no_sensitive_fields(self, access_tier):
+        """Limited response contains no CVE data, severity, or neglected URLs."""
+        mod, _ = _load_vulnerabilities_handler()
+        params = {'query': 'Show CVEs', '_access_tier': access_tier}
+
+        result = mod.handle_query_vulnerabilities(params, 'prop-test')
+
+        for field in SENSITIVE_FIELDS:
+            assert field not in result, f"Sensitive field '{field}' found in limited response"
+
+    @pytest.mark.parametrize('access_tier', NON_PRIVILEGED_TIERS)
+    def test_limited_response_message_present(self, access_tier):
+        """Limited response includes a user-facing message."""
+        mod, _ = _load_vulnerabilities_handler()
+        params = {'query': 'Show CVEs', '_access_tier': access_tier}
+
+        result = mod.handle_query_vulnerabilities(params, 'prop-test')
+
+        assert 'message' in result
+        assert len(result['message']) > 0
+
+    def test_missing_access_tier_defaults_to_limited(self):
+        """When _access_tier key is missing, defaults to limited response."""
+        mod, _ = _load_vulnerabilities_handler()
+        params = {'query': 'Show CVEs'}
+
+        result = mod.handle_query_vulnerabilities(params, 'test-default')
+
+        assert result['status'] == 'success'
+        assert result['access_tier'] == 'limited'
+        assert result['dashboard_url'] == DASHBOARD_URL
+        assert result['results'] == []
+
+    def test_none_access_tier_defaults_to_limited(self):
+        """None access_tier is treated as limited."""
+        mod, _ = _load_vulnerabilities_handler()
+        params = {'query': 'Show CVEs', '_access_tier': None}
+
+        result = mod.handle_query_vulnerabilities(params, 'test-none')
+
+        assert result['access_tier'] == 'limited'
+        assert result['results'] == []
+
+    def test_dashboard_url_has_no_query_params(self):
+        """Dashboard URL is the bare URL with no query parameters."""
+        mod, _ = _load_vulnerabilities_handler()
+        params = {
+            'query': 'Show CVEs',
+            'severity': 'CRITICAL',
+            'age_days': '30',
+            '_access_tier': 'limited',
+        }
+
+        result = mod.handle_query_vulnerabilities(params, 'test-no-params')
+
+        assert '?' not in result['dashboard_url']
+        assert result['dashboard_url'] == DASHBOARD_URL
+
+    @pytest.mark.parametrize('params', [
+        {'query': 'Show CVEs', 'version': '2.19.6', 'severity': 'CRITICAL'},
+        {'query': 'List all high CVEs', 'project_name': 'OpenSearch', 'age_days': '7'},
+        {'query': 'Critical vulnerabilities', 'severity': 'CRITICAL,HIGH'},
+        {'query': 'CVEs for Dashboards'},
+    ])
+    def test_limited_regardless_of_query_params(self, params):
+        """Limited response is the same regardless of query parameters."""
+        mod, _ = _load_vulnerabilities_handler()
+        params['_access_tier'] = 'limited'
+
+        result = mod.handle_query_vulnerabilities(params, 'test-params')
+
+        assert result['status'] == 'success'
+        assert result['access_tier'] == 'limited'
+        assert result['dashboard_url'] == DASHBOARD_URL
+        assert result['results'] == []
+
+
+# ---------------------------------------------------------------------------
+# Property 3: No external calls for limited-access requests
+# ---------------------------------------------------------------------------
+
+
+class TestNoExternalCallsForLimitedAccess:
+    """Property 3: Agentic search is never invoked for limited-access requests.
+
+    For any non-privileged access_tier value and any query parameters,
+    calling handle_query_vulnerabilities SHALL NOT invoke agentic_search
+    or enhance_query.
+
+    **Validates: Requirements 6.1, 6.4**
+    """
+
+    @pytest.mark.parametrize('access_tier', NON_PRIVILEGED_TIERS)
+    def test_agentic_search_never_called(self, access_tier):
+        """Agentic search is never invoked for non-privileged access."""
+        mock_agentic = _make_mock_agentic_search()
+        mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
+        params = {'query': 'Show critical CVEs', '_access_tier': access_tier}
+
+        mod.handle_query_vulnerabilities(params, 'prop-test')
+
+        mock_agentic.agentic_search.assert_not_called()
+
+    @pytest.mark.parametrize('access_tier', NON_PRIVILEGED_TIERS)
+    def test_enhance_query_never_called(self, access_tier):
+        """enhance_query is never invoked for non-privileged access."""
+        mock_agentic = _make_mock_agentic_search()
+        mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
+        params = {'query': 'Show critical CVEs', '_access_tier': access_tier}
+
+        mod.handle_query_vulnerabilities(params, 'prop-test')
+
+        mock_agentic.enhance_query.assert_not_called()
+
+    def test_privileged_does_call_agentic_search(self):
+        """Sanity check: privileged access DOES invoke agentic search."""
+        mock_agentic = _make_mock_agentic_search()
+        mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
+        params = {'query': 'Show CVEs', '_access_tier': 'privileged'}
+
+        mod.handle_query_vulnerabilities(params, 'test-priv')
+
+        mock_agentic.enhance_query.assert_called_once()
+        mock_agentic.agentic_search.assert_called_once()
+
+    @pytest.mark.parametrize('params', [
+        {'query': 'Show CVEs', 'version': '2.19.6', 'severity': 'CRITICAL'},
+        {'query': 'List all high CVEs', 'project_name': 'OpenSearch', 'age_days': '7'},
+        {'query': 'Critical vulnerabilities', 'severity': 'CRITICAL,HIGH'},
+    ])
+    def test_no_external_calls_with_various_params(self, params):
+        """No external calls regardless of query parameters for limited access."""
+        mock_agentic = _make_mock_agentic_search()
+        mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
+        params['_access_tier'] = 'limited'
+
+        mod.handle_query_vulnerabilities(params, 'test-various')
+
+        mock_agentic.agentic_search.assert_not_called()
+        mock_agentic.enhance_query.assert_not_called()

--- a/tests/agents/security_advisories/test_agent.py
+++ b/tests/agents/security_advisories/test_agent.py
@@ -179,7 +179,7 @@ class TestAccessTierInstructions:
         lower = instruction.lower()
         assert "limited" in lower or "dashboard" in lower
 
-
+@pytest.mark.skip(reason="Monitoring config temporarily disabled until log group exists")
 class TestMonitoringConfig:
     """Monitoring config includes all three log markers."""
 

--- a/tests/agents/security_advisories/test_agent.py
+++ b/tests/agents/security_advisories/test_agent.py
@@ -28,7 +28,7 @@ class TestSecurityAdvisoriesAgentInterface:
         assert isinstance(config, LambdaConfig)
 
     def test_get_access_level_returns_privileged(self, agent):
-        assert agent.get_access_level() == "privileged"
+        assert agent.get_access_level() == "both"
 
     def test_uses_knowledge_base_returns_false(self, agent):
         assert agent.uses_knowledge_base() is False
@@ -127,7 +127,59 @@ class TestInstructions:
         assert len(instruction) > 0
 
 
-@pytest.mark.skip(reason="Monitoring config temporarily disabled until log group exists")
+class TestAccessTierInstructions:
+    """Agent instructions contain access-tier-aware formatting guidance."""
+
+    def test_agent_instruction_mentions_access_tier(self, agent):
+        """Agent instruction references access_tier field."""
+        instruction = agent.get_agent_instruction()
+        assert "access_tier" in instruction
+
+    def test_agent_instruction_contains_limited_prohibition(self, agent):
+        """Agent instruction prohibits CVE details for limited-access responses."""
+        instruction = agent.get_agent_instruction()
+        lower = instruction.lower()
+        # Must contain prohibition language for limited access
+        assert "limited" in lower
+        assert "do not" in lower or "shall not" in lower or "do not add" in lower
+
+    def test_agent_instruction_contains_dashboard_link_guidance(self, agent):
+        """Agent instruction mentions dashboard link for limited users."""
+        instruction = agent.get_agent_instruction()
+        assert "dashboard" in instruction.lower()
+        # The instruction tells the agent to use the message field which contains the link
+        assert "message" in instruction.lower()
+
+    def test_agent_instruction_contains_privileged_guidance(self, agent):
+        """Agent instruction describes full inline CVE details for privileged users."""
+        instruction = agent.get_agent_instruction()
+        lower = instruction.lower()
+        assert "privileged" in lower
+        assert "neglected" in lower or "neglected_page_url" in lower
+
+    def test_agent_instruction_prohibits_cve_ids_for_limited(self, agent):
+        """Agent instruction explicitly prohibits CVE identifiers for limited access."""
+        instruction = agent.get_agent_instruction()
+        # The instruction should mention not including CVE identifiers for limited
+        assert "cve" in instruction.lower()
+        # Check that there's prohibition language near limited-access section
+        limited_section_start = instruction.lower().find('access_tier: "limited"')
+        if limited_section_start == -1:
+            limited_section_start = instruction.lower().find("access_tier: \"limited\"")
+        assert limited_section_start != -1, "Instruction must have a limited access_tier section"
+
+    def test_agent_instruction_mentions_neglected_page_link_for_privileged(self, agent):
+        """Agent instruction tells agent to include neglected page link for privileged."""
+        instruction = agent.get_agent_instruction()
+        assert "neglected" in instruction.lower()
+
+    def test_collaborator_instruction_mentions_limited_access(self, agent):
+        """Collaborator instruction mentions dashboard-link-only for limited users."""
+        instruction = agent.get_collaborator_instruction()
+        lower = instruction.lower()
+        assert "limited" in lower or "dashboard" in lower
+
+
 class TestMonitoringConfig:
     """Monitoring config includes all three log markers."""
 

--- a/tests/agents/security_advisories/test_agent.py
+++ b/tests/agents/security_advisories/test_agent.py
@@ -179,6 +179,7 @@ class TestAccessTierInstructions:
         lower = instruction.lower()
         assert "limited" in lower or "dashboard" in lower
 
+
 @pytest.mark.skip(reason="Monitoring config temporarily disabled until log group exists")
 class TestMonitoringConfig:
     """Monitoring config includes all three log markers."""

--- a/tests/agents/security_advisories/test_lambda_function.py
+++ b/tests/agents/security_advisories/test_lambda_function.py
@@ -111,6 +111,7 @@ class TestRoutingToQueryVulnerabilities:
             'parameters': [
                 {'name': 'query', 'value': 'Show critical CVEs'},
             ],
+            'sessionAttributes': {'access_tier': 'privileged'},
         }
         mod.lambda_handler(event, None)
 
@@ -131,6 +132,7 @@ class TestRoutingToQueryVulnerabilities:
                 {'name': 'version', 'value': '2.19.6'},
                 {'name': 'project_name', 'value': 'OpenSearch'},
             ],
+            'sessionAttributes': {'access_tier': 'privileged'},
         }
         mod.lambda_handler(event, None)
 
@@ -155,6 +157,7 @@ class TestRoutingToListProjects:
             'function': 'list_projects',
             'actionGroup': 'securityAdvisoriesActions',
             'parameters': [],
+            'sessionAttributes': {'access_tier': 'privileged'},
         }
         mod.lambda_handler(event, None)
 
@@ -171,6 +174,7 @@ class TestRoutingToListProjects:
             'function': 'list_projects',
             'actionGroup': 'securityAdvisoriesActions',
             'parameters': [],
+            'sessionAttributes': {'access_tier': 'privileged'},
         }
         mod.lambda_handler(event, None)
 
@@ -195,6 +199,7 @@ class TestUnknownFunctionHandling:
             'function': 'nonexistent_function',
             'actionGroup': 'securityAdvisoriesActions',
             'parameters': [],
+            'sessionAttributes': {'access_tier': 'privileged'},
         }
         response = mod.lambda_handler(event, None)
 
@@ -211,6 +216,7 @@ class TestUnknownFunctionHandling:
             'function': 'nonexistent_function',
             'actionGroup': 'securityAdvisoriesActions',
             'parameters': [],
+            'sessionAttributes': {'access_tier': 'privileged'},
         }
         response = mod.lambda_handler(event, None)
 
@@ -228,6 +234,7 @@ class TestUnknownFunctionHandling:
             'function': '',
             'actionGroup': 'securityAdvisoriesActions',
             'parameters': [],
+            'sessionAttributes': {'access_tier': 'privileged'},
         }
         response = mod.lambda_handler(event, None)
 
@@ -285,13 +292,14 @@ class TestParameterParsing:
         event = {
             'function': 'query_vulnerabilities',
             'actionGroup': 'securityAdvisoriesActions',
+            'sessionAttributes': {'access_tier': 'privileged'},
         }
         # Should not raise
         mod.lambda_handler(event, None)
 
         call_args = mock_vuln.handle_query_vulnerabilities.call_args
         params = call_args[0][0]
-        assert params == {}
+        assert params == {'_access_tier': 'privileged'}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agents/security_advisories/test_neglected_url.py
+++ b/tests/agents/security_advisories/test_neglected_url.py
@@ -28,7 +28,7 @@ if _LAMBDA_PATH not in sys.path:
 
 from response_filter import NEGLECTED_PAGE_BASE  # noqa: E402
 from response_filter import VALID_AGE_VALUES  # noqa: E402
-from response_filter import build_neglected_page_url
+from response_filter import build_neglected_page_url  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Property 2: Neglected page URL round-trip

--- a/tests/agents/security_advisories/test_neglected_url.py
+++ b/tests/agents/security_advisories/test_neglected_url.py
@@ -27,7 +27,7 @@ if _LAMBDA_PATH not in sys.path:
     sys.path.insert(0, _LAMBDA_PATH)
 
 from response_filter import NEGLECTED_PAGE_BASE  # noqa: E402
-from response_filter import VALID_AGE_VALUES, build_neglected_page_url
+from response_filter import VALID_AGE_VALUES, build_neglected_page_url  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Property 2: Neglected page URL round-trip

--- a/tests/agents/security_advisories/test_neglected_url.py
+++ b/tests/agents/security_advisories/test_neglected_url.py
@@ -27,7 +27,8 @@ if _LAMBDA_PATH not in sys.path:
     sys.path.insert(0, _LAMBDA_PATH)
 
 from response_filter import NEGLECTED_PAGE_BASE  # noqa: E402
-from response_filter import VALID_AGE_VALUES, build_neglected_page_url  # noqa: E402
+from response_filter import (VALID_AGE_VALUES,  # noqa: E402
+                             build_neglected_page_url)
 
 # ---------------------------------------------------------------------------
 # Property 2: Neglected page URL round-trip

--- a/tests/agents/security_advisories/test_neglected_url.py
+++ b/tests/agents/security_advisories/test_neglected_url.py
@@ -1,0 +1,231 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the neglected page URL builder.
+
+**Property 2: Neglected page URL round-trip**
+For any combination of optional filter parameters, build_neglected_page_url SHALL
+produce a URL that:
+- Starts with the neglected page base URL
+- Contains a query parameter for each non-None input, and no query parameters for None inputs
+- When the URL's query string is parsed back, the parameter values match the original inputs
+
+_Validates: Requirements 3.1, 3.2_
+"""
+
+import os
+import sys
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+# Add the lambda source path
+_LAMBDA_PATH = os.path.join(
+    os.path.dirname(__file__), '..', '..', '..', 'agents', 'security_advisories', 'lambda',
+)
+if _LAMBDA_PATH not in sys.path:
+    sys.path.insert(0, _LAMBDA_PATH)
+
+from response_filter import (NEGLECTED_PAGE_BASE,  # noqa: E402
+                             VALID_AGE_VALUES, build_neglected_page_url)
+
+# ---------------------------------------------------------------------------
+# Property 2: Neglected page URL round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestNeglectedPageUrlRoundTrip:
+    """Property 2: Neglected page URL round-trip.
+
+    For any combination of optional filter parameters, the URL produced by
+    build_neglected_page_url can be parsed back to recover the original inputs.
+
+    **Validates: Requirements 3.1, 3.2**
+    """
+
+    @pytest.mark.parametrize('age', sorted(VALID_AGE_VALUES))
+    def test_round_trip_valid_age(self, age):
+        """Valid age values appear in the URL and can be parsed back."""
+        url = build_neglected_page_url(age=age)
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert url.startswith(NEGLECTED_PAGE_BASE)
+        assert 'age' in params
+        assert params['age'] == [age]
+
+    @pytest.mark.parametrize('age', ['5d', '99d', '100d', '', 'abc', '0'])
+    def test_invalid_age_excluded(self, age):
+        """Invalid age values are not included in the URL."""
+        url = build_neglected_page_url(age=age)
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert 'age' not in params
+
+    @pytest.mark.parametrize('severe', [True, False])
+    def test_round_trip_severe(self, severe):
+        """severe boolean appears in the URL as 'true' or 'false'."""
+        url = build_neglected_page_url(severe=severe)
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert 'severe' in params
+        assert params['severe'] == [str(severe).lower()]
+
+    def test_severe_none_excluded(self):
+        """severe=None is not included in the URL."""
+        url = build_neglected_page_url(severe=None)
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert 'severe' not in params
+
+    @pytest.mark.parametrize('releases', [True, False])
+    def test_round_trip_releases(self, releases):
+        """releases boolean appears in the URL as 'true' or 'false'."""
+        url = build_neglected_page_url(releases=releases)
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert 'releases' in params
+        assert params['releases'] == [str(releases).lower()]
+
+    def test_releases_none_excluded(self):
+        """releases=None is not included in the URL."""
+        url = build_neglected_page_url(releases=None)
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert 'releases' not in params
+
+    @pytest.mark.parametrize('critical', [True, False])
+    def test_round_trip_critical(self, critical):
+        """critical boolean appears in the URL as 'true' or 'false'."""
+        url = build_neglected_page_url(critical=critical)
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert 'critical' in params
+        assert params['critical'] == [str(critical).lower()]
+
+    def test_critical_none_excluded(self):
+        """critical=None is not included in the URL."""
+        url = build_neglected_page_url(critical=None)
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert 'critical' not in params
+
+    @pytest.mark.parametrize('tag', ['2.19.6', 'origin/main', '1.2.0.1', '2.x'])
+    def test_round_trip_tag(self, tag):
+        """tag string appears in the URL query string."""
+        url = build_neglected_page_url(tag=tag)
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert 'tag' in params
+        assert params['tag'] == [tag]
+
+    @pytest.mark.parametrize('tag', ['', None])
+    def test_empty_or_none_tag_excluded(self, tag):
+        """Empty or None tag is not included in the URL."""
+        url = build_neglected_page_url(tag=tag)
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert 'tag' not in params
+
+    def test_all_params_round_trip(self):
+        """All parameters provided can be parsed back from the URL."""
+        url = build_neglected_page_url(
+            age='30d', severe=True, releases=True, critical=False, tag='2.19.6',
+        )
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert params['age'] == ['30d']
+        assert params['severe'] == ['true']
+        assert params['releases'] == ['true']
+        assert params['critical'] == ['false']
+        assert params['tag'] == ['2.19.6']
+
+    def test_no_extra_params_when_all_provided(self):
+        """URL contains exactly the expected parameters and no extras."""
+        url = build_neglected_page_url(
+            age='45d', severe=False, releases=True, critical=True, tag='main',
+        )
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert set(params.keys()) == {'age', 'severe', 'releases', 'critical', 'tag'}
+
+    def test_no_extra_params_when_subset_provided(self):
+        """URL contains only parameters for non-None inputs."""
+        url = build_neglected_page_url(age='15d', tag='2.x')
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert set(params.keys()) == {'age', 'tag'}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for specific cases
+# ---------------------------------------------------------------------------
+
+
+class TestNeglectedPageUrlUnitTests:
+    """Unit tests for specific edge cases and examples."""
+
+    def test_no_params_returns_base_url(self):
+        """No parameters returns the bare base URL."""
+        url = build_neglected_page_url()
+        assert url == NEGLECTED_PAGE_BASE
+
+    def test_all_none_returns_base_url(self):
+        """All None parameters returns the bare base URL."""
+        url = build_neglected_page_url(
+            age=None, severe=None, releases=None, critical=None, tag=None,
+        )
+        assert url == NEGLECTED_PAGE_BASE
+
+    def test_url_always_starts_with_base(self):
+        """URL always starts with the neglected page base."""
+        url = build_neglected_page_url(age='30d', severe=True)
+        assert url.startswith(NEGLECTED_PAGE_BASE)
+
+    def test_params_are_sorted(self):
+        """Query parameters are sorted alphabetically for deterministic output."""
+        url = build_neglected_page_url(
+            age='30d', severe=True, releases=True, critical=True, tag='main',
+        )
+        query = url.split('?')[1]
+        param_names = [p.split('=')[0] for p in query.split('&')]
+        assert param_names == sorted(param_names)
+
+    def test_severe_false_included(self):
+        """severe=False is included as 'false' (not omitted)."""
+        url = build_neglected_page_url(severe=False)
+        assert 'severe=false' in url
+
+    def test_releases_false_included(self):
+        """releases=False is included as 'false' (not omitted)."""
+        url = build_neglected_page_url(releases=False)
+        assert 'releases=false' in url
+
+    def test_critical_false_included(self):
+        """critical=False is included as 'false' (not omitted)."""
+        url = build_neglected_page_url(critical=False)
+        assert 'critical=false' in url
+
+    def test_example_from_design_doc(self):
+        """Matches the example URL from the design document."""
+        url = build_neglected_page_url(
+            age='30d', severe=True, releases=True, critical=False, tag='2.19.6',
+        )
+        # Verify all expected params are present
+        assert 'age=30d' in url
+        assert 'severe=true' in url
+        assert 'releases=true' in url
+        assert 'critical=false' in url
+        assert 'tag=2.19.6' in url

--- a/tests/agents/security_advisories/test_neglected_url.py
+++ b/tests/agents/security_advisories/test_neglected_url.py
@@ -26,8 +26,8 @@ _LAMBDA_PATH = os.path.join(
 if _LAMBDA_PATH not in sys.path:
     sys.path.insert(0, _LAMBDA_PATH)
 
-from response_filter import (NEGLECTED_PAGE_BASE,  # noqa: E402
-                             VALID_AGE_VALUES, build_neglected_page_url)
+from response_filter import NEGLECTED_PAGE_BASE  # noqa: E402
+from response_filter import VALID_AGE_VALUES, build_neglected_page_url
 
 # ---------------------------------------------------------------------------
 # Property 2: Neglected page URL round-trip

--- a/tests/agents/security_advisories/test_neglected_url.py
+++ b/tests/agents/security_advisories/test_neglected_url.py
@@ -27,8 +27,8 @@ if _LAMBDA_PATH not in sys.path:
     sys.path.insert(0, _LAMBDA_PATH)
 
 from response_filter import NEGLECTED_PAGE_BASE  # noqa: E402
-from response_filter import (VALID_AGE_VALUES,  # noqa: E402
-                             build_neglected_page_url)
+from response_filter import VALID_AGE_VALUES  # noqa: E402
+from response_filter import build_neglected_page_url
 
 # ---------------------------------------------------------------------------
 # Property 2: Neglected page URL round-trip

--- a/tests/agents/security_advisories/test_severity_and_age_filtering.py
+++ b/tests/agents/security_advisories/test_severity_and_age_filtering.py
@@ -288,7 +288,7 @@ class TestSeverityFilteringIntegration:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs', 'severity': 'CRITICAL'}, 'test-sev-001',
+            {'query': 'Show CVEs', 'severity': 'CRITICAL', '_access_tier': 'privileged'}, 'test-sev-001',
         )
 
         assert result['status'] == 'success'
@@ -309,7 +309,7 @@ class TestSeverityFilteringIntegration:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs', 'severity': 'CRITICAL,HIGH'}, 'test-sev-002',
+            {'query': 'Show CVEs', 'severity': 'CRITICAL,HIGH', '_access_tier': 'privileged'}, 'test-sev-002',
         )
 
         entry = result['results'][0]
@@ -330,7 +330,7 @@ class TestSeverityFilteringIntegration:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs'}, 'test-sev-003',
+            {'query': 'Show CVEs', '_access_tier': 'privileged'}, 'test-sev-003',
         )
 
         entry = result['results'][0]
@@ -349,7 +349,7 @@ class TestSeverityFilteringIntegration:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs', 'severity': 'CRITICAL'}, 'test-sev-004',
+            {'query': 'Show CVEs', 'severity': 'CRITICAL', '_access_tier': 'privileged'}, 'test-sev-004',
         )
 
         entry = result['results'][0]
@@ -366,7 +366,7 @@ class TestSeverityFilteringIntegration:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs', 'severity': 'CRITICAL'}, 'test-sev-005',
+            {'query': 'Show CVEs', 'severity': 'CRITICAL', '_access_tier': 'privileged'}, 'test-sev-005',
         )
 
         entry = result['results'][0]
@@ -393,7 +393,7 @@ class TestAgeThresholdFilteringIntegration:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs', 'age_days': '30'}, 'test-age-001',
+            {'query': 'Show CVEs', 'age_days': '30', '_access_tier': 'privileged'}, 'test-age-001',
         )
 
         assert result['result_count'] == 1
@@ -409,7 +409,7 @@ class TestAgeThresholdFilteringIntegration:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs', 'age_days': '30'}, 'test-age-002',
+            {'query': 'Show CVEs', 'age_days': '30', '_access_tier': 'privileged'}, 'test-age-002',
         )
 
         assert result['result_count'] == 0
@@ -432,7 +432,7 @@ class TestAgeThresholdFilteringIntegration:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs', 'age_days': '30'}, 'test-age-003',
+            {'query': 'Show CVEs', 'age_days': '30', '_access_tier': 'privileged'}, 'test-age-003',
         )
 
         assert result['result_count'] == 1
@@ -449,7 +449,7 @@ class TestAgeThresholdFilteringIntegration:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs'}, 'test-age-004',
+            {'query': 'Show CVEs', '_access_tier': 'privileged'}, 'test-age-004',
         )
 
         assert result['result_count'] == 1
@@ -465,7 +465,7 @@ class TestAgeThresholdFilteringIntegration:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs', 'age_days': 'abc'}, 'test-age-005',
+            {'query': 'Show CVEs', 'age_days': 'abc', '_access_tier': 'privileged'}, 'test-age-005',
         )
 
         assert result['result_count'] == 1
@@ -481,7 +481,7 @@ class TestAgeThresholdFilteringIntegration:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs', 'age_days': '7'}, 'test-age-006',
+            {'query': 'Show CVEs', 'age_days': '7', '_access_tier': 'privileged'}, 'test-age-006',
         )
 
         assert result['result_count'] == 1
@@ -503,7 +503,7 @@ class TestAgeThresholdFilteringIntegration:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs', 'age_days': '7'}, 'test-age-007',
+            {'query': 'Show CVEs', 'age_days': '7', '_access_tier': 'privileged'}, 'test-age-007',
         )
 
         assert result['status'] == 'success'
@@ -540,7 +540,7 @@ class TestCombinedSeverityAndAgeFiltering:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs', 'severity': 'CRITICAL', 'age_days': '30'},
+            {'query': 'Show CVEs', 'severity': 'CRITICAL', 'age_days': '30', '_access_tier': 'privileged'},
             'test-combo-001',
         )
 
@@ -564,7 +564,7 @@ class TestCombinedSeverityAndAgeFiltering:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs', 'severity': 'CRITICAL', 'age_days': '7'},
+            {'query': 'Show CVEs', 'severity': 'CRITICAL', 'age_days': '7', '_access_tier': 'privileged'},
             'test-combo-002',
         )
 

--- a/tests/agents/security_advisories/test_vulnerabilities_handler.py
+++ b/tests/agents/security_advisories/test_vulnerabilities_handler.py
@@ -137,7 +137,7 @@ class TestResultEntryStructuralCompleteness:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show critical CVEs'}, 'test-001',
+            {'query': 'Show critical CVEs', '_access_tier': 'privileged'}, 'test-001',
         )
 
         assert result['status'] == 'success'
@@ -153,7 +153,7 @@ class TestResultEntryStructuralCompleteness:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs'}, 'test-002',
+            {'query': 'Show CVEs', '_access_tier': 'privileged'}, 'test-002',
         )
 
         entry = result['results'][0]
@@ -167,7 +167,7 @@ class TestResultEntryStructuralCompleteness:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs'}, 'test-003',
+            {'query': 'Show CVEs', '_access_tier': 'privileged'}, 'test-003',
         )
 
         entry = result['results'][0]
@@ -181,7 +181,7 @@ class TestResultEntryStructuralCompleteness:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs'}, 'test-004',
+            {'query': 'Show CVEs', '_access_tier': 'privileged'}, 'test-004',
         )
 
         entry = result['results'][0]
@@ -195,7 +195,7 @@ class TestResultEntryStructuralCompleteness:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs'}, 'test-005',
+            {'query': 'Show CVEs', '_access_tier': 'privileged'}, 'test-005',
         )
 
         entry = result['results'][0]
@@ -209,7 +209,7 @@ class TestResultEntryStructuralCompleteness:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs'}, 'test-006',
+            {'query': 'Show CVEs', '_access_tier': 'privileged'}, 'test-006',
         )
 
         entry = result['results'][0]
@@ -236,7 +236,7 @@ class TestVulnerabilityExtractionCompleteness:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show all CVEs'}, 'test-010',
+            {'query': 'Show all CVEs', '_access_tier': 'privileged'}, 'test-010',
         )
 
         assert result['status'] == 'success'
@@ -251,7 +251,7 @@ class TestVulnerabilityExtractionCompleteness:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs'}, 'test-011',
+            {'query': 'Show CVEs', '_access_tier': 'privileged'}, 'test-011',
         )
 
         assert result['result_count'] == 1
@@ -274,7 +274,7 @@ class TestVulnerabilityExtractionCompleteness:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show all CVEs'}, 'test-012',
+            {'query': 'Show all CVEs', '_access_tier': 'privileged'}, 'test-012',
         )
 
         assert result['result_count'] == 3
@@ -297,7 +297,7 @@ class TestEmptyResults:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs for nonexistent project'}, 'test-020',
+            {'query': 'Show CVEs for nonexistent project', '_access_tier': 'privileged'}, 'test-020',
         )
 
         assert result['status'] == 'success'
@@ -311,7 +311,7 @@ class TestEmptyResults:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs'}, 'test-021',
+            {'query': 'Show CVEs', '_access_tier': 'privileged'}, 'test-021',
         )
 
         assert result['status'] == 'success'
@@ -334,7 +334,7 @@ class TestAgenticSearchErrorHandling:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs'}, 'test-030',
+            {'query': 'Show CVEs', '_access_tier': 'privileged'}, 'test-030',
         )
 
         assert result['status'] == 'error'
@@ -350,7 +350,7 @@ class TestAgenticSearchErrorHandling:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs'}, 'test-031',
+            {'query': 'Show CVEs', '_access_tier': 'privileged'}, 'test-031',
         )
 
         assert result['status'] == 'error'
@@ -364,8 +364,143 @@ class TestAgenticSearchErrorHandling:
         mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
 
         result = mod.handle_query_vulnerabilities(
-            {'query': 'Show CVEs'}, 'test-032',
+            {'query': 'Show CVEs', '_access_tier': 'privileged'}, 'test-032',
         )
 
         assert 'message' in result
         assert len(result['message']) > 0
+
+# ---------------------------------------------------------------------------
+# Privileged response enrichment (access_tier and neglected_page_url)
+# ---------------------------------------------------------------------------
+
+
+class TestPrivilegedResponseEnrichment:
+    """Test that privileged responses include access_tier and neglected_page_url.
+
+    _Validates: Requirements 2.1, 3.1, 5.2_
+    """
+
+    def test_privileged_response_has_access_tier(self):
+        """Privileged response includes access_tier: 'privileged'."""
+        mock_agentic = _make_mock_agentic_search()
+        mock_agentic.agentic_search.return_value = {
+            'hits': {'hits': [SAMPLE_HIT]},
+        }
+        mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
+
+        result = mod.handle_query_vulnerabilities(
+            {'query': 'Show CVEs', '_access_tier': 'privileged'}, 'test-040',
+        )
+
+        assert result['access_tier'] == 'privileged'
+
+    def test_privileged_response_has_neglected_page_url(self):
+        """Privileged response includes neglected_page_url field."""
+        mock_agentic = _make_mock_agentic_search()
+        mock_agentic.agentic_search.return_value = {
+            'hits': {'hits': [SAMPLE_HIT]},
+        }
+        mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
+
+        result = mod.handle_query_vulnerabilities(
+            {'query': 'Show CVEs', '_access_tier': 'privileged'}, 'test-041',
+        )
+
+        assert 'neglected_page_url' in result
+        assert result['neglected_page_url'].startswith(
+            'https://advisories.opensearch.org/advisories/neglected/',
+        )
+
+    def test_neglected_url_includes_age_param(self):
+        """Neglected URL includes age parameter when provided in query."""
+        mock_agentic = _make_mock_agentic_search()
+        mock_agentic.agentic_search.return_value = {
+            'hits': {'hits': [SAMPLE_HIT]},
+        }
+        mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
+
+        result = mod.handle_query_vulnerabilities(
+            {'query': 'Show CVEs', 'age': '30d', '_access_tier': 'privileged'}, 'test-042',
+        )
+
+        assert 'age=30d' in result['neglected_page_url']
+
+    def test_neglected_url_includes_severe_param(self):
+        """Neglected URL includes severe parameter when provided."""
+        mock_agentic = _make_mock_agentic_search()
+        mock_agentic.agentic_search.return_value = {
+            'hits': {'hits': [SAMPLE_HIT]},
+        }
+        mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
+
+        result = mod.handle_query_vulnerabilities(
+            {'query': 'Show CVEs', 'severe': 'true', '_access_tier': 'privileged'}, 'test-043',
+        )
+
+        assert 'severe=true' in result['neglected_page_url']
+
+    def test_neglected_url_includes_tag_param(self):
+        """Neglected URL includes tag parameter when provided."""
+        mock_agentic = _make_mock_agentic_search()
+        mock_agentic.agentic_search.return_value = {
+            'hits': {'hits': [SAMPLE_HIT]},
+        }
+        mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
+
+        result = mod.handle_query_vulnerabilities(
+            {'query': 'Show CVEs', 'tag': '2.19.6', '_access_tier': 'privileged'}, 'test-044',
+        )
+
+        assert 'tag=2.19.6' in result['neglected_page_url']
+
+    def test_neglected_url_includes_releases_and_critical(self):
+        """Neglected URL includes releases and critical params when provided."""
+        mock_agentic = _make_mock_agentic_search()
+        mock_agentic.agentic_search.return_value = {
+            'hits': {'hits': [SAMPLE_HIT]},
+        }
+        mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
+
+        result = mod.handle_query_vulnerabilities(
+            {
+                'query': 'Show CVEs',
+                'releases': 'true',
+                'critical': 'false',
+                '_access_tier': 'privileged',
+            },
+            'test-045',
+        )
+
+        assert 'releases=true' in result['neglected_page_url']
+        assert 'critical=false' in result['neglected_page_url']
+
+    def test_neglected_url_base_when_no_filter_params(self):
+        """Neglected URL is the base URL when no filter params are provided."""
+        mock_agentic = _make_mock_agentic_search()
+        mock_agentic.agentic_search.return_value = {
+            'hits': {'hits': [SAMPLE_HIT]},
+        }
+        mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
+
+        result = mod.handle_query_vulnerabilities(
+            {'query': 'Show CVEs', '_access_tier': 'privileged'}, 'test-046',
+        )
+
+        assert result['neglected_page_url'] == 'https://advisories.opensearch.org/advisories/neglected/'
+
+    def test_empty_results_still_has_neglected_url(self):
+        """Even with no hits, privileged response includes neglected_page_url."""
+        mock_agentic = _make_mock_agentic_search()
+        mock_agentic.agentic_search.return_value = {
+            'hits': {'hits': []},
+        }
+        mod, _ = _load_vulnerabilities_handler(mock_agentic=mock_agentic)
+
+        result = mod.handle_query_vulnerabilities(
+            {'query': 'Show CVEs for nonexistent', '_access_tier': 'privileged'}, 'test-047',
+        )
+
+        # Empty results return a message-style response, which may or may not have neglected_url
+        # The key point is it doesn't crash and returns success
+        assert result['status'] == 'success'

--- a/tests/agents/test_agent_integration.py
+++ b/tests/agents/test_agent_integration.py
@@ -107,7 +107,7 @@ class TestAgentRegistration:
         assert MetricsAgent().get_access_level() == "both"
 
     def test_security_advisories_access_level(self):
-        assert SecurityAdvisoriesAgent().get_access_level() == "privileged"
+        assert SecurityAdvisoriesAgent().get_access_level() == "both"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/lambda/oscar_agent/bedrock/test_agent_invoker.py
+++ b/tests/lambda/oscar_agent/bedrock/test_agent_invoker.py
@@ -66,6 +66,68 @@ class TestCreateAgentRequest:
         assert req['inputText'] == 'what is opensearch?'
 
 
+class TestSessionAttributeInjection:
+    """Validates Property 4: Session attribute injection correctness.
+
+    For any invocation of create_agent_request(query, privilege, session_id):
+    - If privilege is True, the request SHALL contain access_tier == "privileged"
+    - If privilege is False, the request SHALL contain access_tier == "limited"
+
+    _Requirements: 5.1, 5.2_
+    """
+
+    def test_privilege_true_sets_access_tier_privileged(self, agent_core):
+        """privilege=True produces access_tier: 'privileged' in sessionState."""
+        core, _ = agent_core
+        req = core.create_agent_request('show CVEs', privilege=True)
+        assert req['sessionState']['sessionAttributes']['access_tier'] == 'privileged'
+
+    def test_privilege_false_sets_access_tier_limited(self, agent_core):
+        """privilege=False produces access_tier: 'limited' in sessionState."""
+        core, _ = agent_core
+        req = core.create_agent_request('show CVEs', privilege=False)
+        assert req['sessionState']['sessionAttributes']['access_tier'] == 'limited'
+
+    def test_session_state_structure_present(self, agent_core):
+        """Request always contains sessionState.sessionAttributes dict."""
+        core, _ = agent_core
+        req = core.create_agent_request('hello', privilege=True)
+        assert 'sessionState' in req
+        assert 'sessionAttributes' in req['sessionState']
+        assert isinstance(req['sessionState']['sessionAttributes'], dict)
+
+    def test_privileged_preserves_other_request_fields(self, agent_core):
+        """Session attribute injection does not break other request fields."""
+        core, _ = agent_core
+        req = core.create_agent_request('test query', privilege=True, session_id='sess-123')
+        assert req['agentId'] == 'priv-agent'
+        assert req['agentAliasId'] == 'priv-alias'
+        assert req['inputText'] == 'test query'
+        assert req['sessionId'] == 'sess-123'
+        assert req['enableTrace'] is True
+        assert req['sessionState']['sessionAttributes']['access_tier'] == 'privileged'
+
+    def test_limited_preserves_other_request_fields(self, agent_core):
+        """Session attribute injection does not break other request fields."""
+        core, _ = agent_core
+        req = core.create_agent_request('test query', privilege=False, session_id='sess-456')
+        assert req['agentId'] == 'ltd-agent'
+        assert req['agentAliasId'] == 'ltd-alias'
+        assert req['inputText'] == 'test query'
+        assert req['sessionId'] == 'sess-456'
+        assert req['enableTrace'] is True
+        assert req['sessionState']['sessionAttributes']['access_tier'] == 'limited'
+
+    def test_access_tier_is_only_session_attribute(self, agent_core):
+        """Only access_tier is set in sessionAttributes (no extra keys)."""
+        core, _ = agent_core
+        req = core.create_agent_request('hello', privilege=True)
+        assert req['sessionState']['sessionAttributes'] == {'access_tier': 'privileged'}
+
+        req = core.create_agent_request('hello', privilege=False)
+        assert req['sessionState']['sessionAttributes'] == {'access_tier': 'limited'}
+
+
 class TestInvokeAgent:
 
     def test_returns_assembled_text(self, agent_core):

--- a/tests/lambda/oscar_agent/slack_handler/test_message_processor.py
+++ b/tests/lambda/oscar_agent/slack_handler/test_message_processor.py
@@ -173,3 +173,44 @@ class TestProcessMessage:
                            message_ts='mts', skip_context_storage=True)
 
         storage.update_context.assert_not_called()
+
+    def test_limited_user_advisory_response_is_overridden(self):
+        """Non-privileged user gets canonical dashboard message when response contains advisory link."""
+        mp, _, say = self._setup()
+        advisory_response = (
+            'Here is a detailed CVE breakdown from advisories.opensearch.org with specifics.'
+        )
+        mp.timeout_handler.query_agent_with_timeout.return_value = (advisory_response, 'sess2')
+
+        mp.process_message('C_ALLOWED', 'tts', 'U_NOBODY', '<@BOT> show vulns', say, message_ts='mts')
+
+        sent_text = say.call_args[1]['text']
+        assert 'Security Advisory Dashboard' in sent_text
+        assert 'advisories.opensearch.org' in sent_text
+        # The original detailed content should NOT be present
+        assert 'detailed CVE breakdown' not in sent_text
+
+    def test_privileged_user_advisory_response_not_overridden(self):
+        """Privileged user receives the full agent response even when it contains advisory link."""
+        mp, _, say = self._setup()
+        advisory_response = (
+            'Here is a detailed CVE breakdown from advisories.opensearch.org with specifics.'
+        )
+        mp.timeout_handler.query_agent_with_timeout.return_value = (advisory_response, 'sess2')
+
+        mp.process_message('C_ALLOWED', 'tts', 'U_ADMIN', '<@BOT> show vulns', say, message_ts='mts')
+
+        sent_text = say.call_args[1]['text']
+        assert 'detailed CVE breakdown' in sent_text
+
+    def test_limited_user_non_advisory_response_not_overridden(self):
+        """Non-privileged user gets normal response when it doesn't contain advisory link."""
+        mp, _, say = self._setup()
+        normal_response = 'Here are the latest metrics for your project.'
+        mp.timeout_handler.query_agent_with_timeout.return_value = (normal_response, 'sess2')
+
+        mp.process_message('C_ALLOWED', 'tts', 'U_NOBODY', '<@BOT> show metrics', say, message_ts='mts')
+
+        sent_text = say.call_args[1]['text']
+        assert 'latest metrics' in sent_text
+        assert 'Security Advisory Dashboard' not in sent_text


### PR DESCRIPTION
## Description

Adds two-tier access control to the Security Advisories collaborator agent. Limited-access users receive only a dashboard link; privileged users receive full inline CVE details. The access tier is propagated via session attributes from the supervisor agent invocation — no LLM involvement in the access decision.

## Changes

- **Session attribute propagation**: `agent_invoker.py` and `query_processor.py` inject `access_tier` into `sessionState.sessionAttributes` based on `is_fully_authorized_user()`
- **Lambda router gating**: `lambda_function.py` checks `access_tier` from session attributes and returns dashboard-link-only response immediately for limited users without invoking any handler or search
- **Tiered agent instructions**: `instructions.py` now has distinct instruction sets for privileged vs limited invocations, guiding the LLM to never surface CVE data for limited users
- **App-layer defense-in-depth**: `message_formatter.py` detects when a limited-access user's response contains the advisory dashboard marker and replaces the entire LLM output with a fixed dashboard-only message, preventing any hallucinated CVE details from leaking through the supervisor's commentary.
- **Neglected page URL builder**: `response_filter.py` adds `build_neglected_page_url()` for generating parameterized links to the neglected vulnerabilities page
- **Tests**: New test modules for access tier resolution, neglected URL generation, agent invoker session attribute propagation, and expanded coverage for vulnerabilities handler and lambda function

## Testing

- `test_access_tier.py` — verifies limited vs privileged routing and response content
- `test_neglected_url.py` — validates parameterized neglected page link generation
- `test_agent_invoker.py` — confirms session attribute injection
- Expanded existing tests for lambda function, vulnerabilities handler, and severity/age filtering

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
