### PR TITLE
Fix jenkins parser for case-sensitive extensions

### DIFF
--- a/agents/jenkins/lambda/jenkinsfile_fetcher.py
+++ b/agents/jenkins/lambda/jenkinsfile_fetcher.py
@@ -79,7 +79,7 @@ def _discover_jenkinsfiles(directory: str = None) -> List[str]:
                     continue
                 if item.get("type") == "dir":
                     dirs_to_visit.append(item_path)
-                elif item.get("type") == "file" and item_path.endswith(".jenkinsfile"):
+                elif item.get("type") == "file" and item_path.lower().endswith(".jenkinsfile"):
                     paths.append(item_path)
 
         except requests.RequestException as e:

--- a/tests/agents/jenkins/test_jenkins.py
+++ b/tests/agents/jenkins/test_jenkins.py
@@ -6,7 +6,7 @@
 import os
 import sys
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 # Add jenkins directory to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..', 'agents', 'jenkins', 'lambda'))
@@ -405,6 +405,40 @@ class TestJobParameterFormatting(unittest.TestCase):
         """Test parameter formatting with no parameters."""
         result = format_parameters_as_bullets({})
         self.assertEqual(result, "• No parameters required")
+
+
+class TestJenkinsfileDiscovery(unittest.TestCase):
+    """Test Jenkinsfile discovery handles case-insensitive extensions."""
+
+    @patch('jenkinsfile_fetcher.requests.get')
+    @patch('jenkinsfile_fetcher.config')
+    def test_discovers_jenkinsfile_case_insensitive(self, mock_config, mock_get):
+        """Test that files with .jenkinsFile (capital F) are discovered."""
+        from jenkinsfile_fetcher import _discover_jenkinsfiles
+
+        mock_config.jenkins_dir = 'jenkins'
+        mock_config.github_repo = 'opensearch-project/opensearch-build'
+        mock_config.github_branch = 'main'
+        mock_config.github_token = None
+        mock_config.jenkinsfile_ignore_list = []
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {'path': 'jenkins/check-for-build.jenkinsfile', 'type': 'file'},
+            {'path': 'jenkins/manifests-update.jenkinsFile', 'type': 'file'},
+            {'path': 'jenkins/some-job.JENKINSFILE', 'type': 'file'},
+            {'path': 'jenkins/not-a-jenkinsfile.groovy', 'type': 'file'},
+        ]
+        mock_get.return_value = mock_response
+
+        paths = _discover_jenkinsfiles()
+
+        self.assertIn('jenkins/check-for-build.jenkinsfile', paths)
+        self.assertIn('jenkins/manifests-update.jenkinsFile', paths)
+        self.assertIn('jenkins/some-job.JENKINSFILE', paths)
+        self.assertNotIn('jenkins/not-a-jenkinsfile.groovy', paths)
+        self.assertEqual(len(paths), 3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description
Fix jenkins parser for case-sensitive extensions

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
