### PR TITLE
Defer security advisories monitoring until log group exists

### DIFF
--- a/agents/security_advisories/agent.py
+++ b/agents/security_advisories/agent.py
@@ -5,8 +5,8 @@
 
 import os
 
-from agents.base_agent import (LambdaConfig, MonitoringConfig, OscarAgent,
-                               SecretConfig)
+from agents.base_agent import (LambdaConfig, MonitoringConfig,  # noqa: F401
+                               OscarAgent, SecretConfig)
 from agents.security_advisories.action_groups import get_action_groups
 from agents.security_advisories.iam_policies import get_policies
 from agents.security_advisories.instructions import (AGENT_INSTRUCTION,

--- a/agents/security_advisories/agent.py
+++ b/agents/security_advisories/agent.py
@@ -80,20 +80,22 @@ class SecurityAdvisoriesAgent(OscarAgent):
         ]
 
     def get_monitoring_config(self):
-        return [
-            MonitoringConfig(
-                pattern="SECURITY_ADVISORIES_AGENTIC_SEARCH_FAILED",
-                alarm_threshold=5,
-                description="OpenSearch agentic query failures",
-            ),
-            MonitoringConfig(
-                pattern="SECURITY_ADVISORIES_OPENSEARCH_CONNECTION_FAILED",
-                alarm_threshold=2,
-                description="OpenSearch connectivity issues",
-            ),
-            MonitoringConfig(
-                pattern="SECURITY_ADVISORIES_CROSS_ACCOUNT_ROLE_FAILED",
-                alarm_threshold=1,
-                description="Cross-account role assumption failure",
-            ),
-        ]
+        # TODO: Re-enable after first deployment so the log group exists.
+        # return [
+        #     MonitoringConfig(
+        #         pattern="SECURITY_ADVISORIES_AGENTIC_SEARCH_FAILED",
+        #         alarm_threshold=5,
+        #         description="OpenSearch agentic query failures",
+        #     ),
+        #     MonitoringConfig(
+        #         pattern="SECURITY_ADVISORIES_OPENSEARCH_CONNECTION_FAILED",
+        #         alarm_threshold=2,
+        #         description="OpenSearch connectivity issues",
+        #     ),
+        #     MonitoringConfig(
+        #         pattern="SECURITY_ADVISORIES_CROSS_ACCOUNT_ROLE_FAILED",
+        #         alarm_threshold=1,
+        #         description="Cross-account role assumption failure",
+        #     ),
+        # ]
+        return []

--- a/tests/agents/security_advisories/test_agent.py
+++ b/tests/agents/security_advisories/test_agent.py
@@ -127,6 +127,7 @@ class TestInstructions:
         assert len(instruction) > 0
 
 
+@pytest.mark.skip(reason="Monitoring config temporarily disabled until log group exists")
 class TestMonitoringConfig:
     """Monitoring config includes all three log markers."""
 


### PR DESCRIPTION
### Description
Temporarily disables monitoring config for the Security Advisories agent. The CloudWatch metric filters fail during deployment because the Lambda log group doesn't exist yet (it's auto-created on first invocation). This defers monitoring until the next PR after the Lambda has been invoked at least once.

### Issues Resolved
Fixes OscarSecurityMonitoringStack deployment failure: "The specified log group does not exist" for Security Advisories metric filters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
