### PR TITLE
Address PR feedback on DSL query builder

### DIFF
--- a/agents/security_advisories/lambda/dsl_query_builder.py
+++ b/agents/security_advisories/lambda/dsl_query_builder.py
@@ -15,6 +15,7 @@ Functions:
 
 import json
 import logging
+import re
 from typing import Any, Dict, Optional
 
 import semver
@@ -25,6 +26,10 @@ logger.setLevel(logging.INFO)
 
 # Default query size — matches the previous agentic search configuration
 _DEFAULT_QUERY_SIZE = 1000
+
+# Strict two-part numeric pattern (e.g., "3.7", "2.19") to avoid
+# misclassifying pre-release/build metadata strings like "3.7-rc".
+_TWO_PART_RE = re.compile(r'^\d+\.\d+$')
 
 
 def _classify_version(version: str) -> str:
@@ -39,13 +44,15 @@ def _classify_version(version: str) -> str:
     try:
         semver.Version.parse(version)
         return 'three_part'
-    except ValueError:
+    except (ValueError, TypeError):
         pass
-    try:
-        semver.Version.parse(f'{version}.0')
-        return 'two_part'
-    except ValueError:
-        return 'unknown'
+    if _TWO_PART_RE.match(version):
+        try:
+            semver.Version.parse(f'{version}.0')
+            return 'two_part'
+        except (ValueError, TypeError):
+            pass
+    return 'unknown'
 
 
 def resolve_version_tag(version: str) -> str:
@@ -210,22 +217,21 @@ def _error_response(
 def _connection_error(exception: Exception) -> Dict[str, Any]:
     """Return a connection error without leaking internal details.
 
-    Sanitizes the error message to exclude internal hostnames or credentials
-    that may appear in connection failure exceptions.
+    Logs the original exception internally for diagnostics, then returns
+    a sanitized error dict via _error_response for consistent structure.
 
     Args:
         exception: The caught exception from the connection failure.
 
     Returns:
-        Sanitized error dict.
+        Sanitized error dict with consistent structure.
     """
-    return {
-        'status': 'error',
-        'type': 'connection_error',
-        'retryable': False,
-        'message': 'Failed to connect to the OpenSearch cluster. '
-                   'The service may be temporarily unavailable.',
-    }
+    logger.error(f'CONNECTION_ERROR: {type(exception).__name__}: {exception}')
+    return _error_response(
+        'connection_error',
+        'Failed to connect to the OpenSearch cluster. '
+        'The service may be temporarily unavailable.',
+    )
 
 
 def query_vulnerabilities(
@@ -255,8 +261,16 @@ def query_vulnerabilities(
         )
         return _error_response('index_resolution_error', str(e))
 
-    # Resolve version tag — default to origin/main per agent instructions
-    resolved_tag = resolve_version_tag(version) if version else 'origin/main'
+    # Resolve version tag:
+    # - version provided → resolve to canonical tag format
+    # - only project_name provided → no tag filter (return all versions)
+    # - neither provided → default to origin/main
+    if version:
+        resolved_tag = resolve_version_tag(version)
+    elif project_name:
+        resolved_tag = None
+    else:
+        resolved_tag = 'origin/main'
 
     # Build the DSL query
     query_body_dict = _build_dsl_query(

--- a/agents/security_advisories/lambda/vulnerabilities_handler.py
+++ b/agents/security_advisories/lambda/vulnerabilities_handler.py
@@ -149,20 +149,6 @@ def handle_query_vulnerabilities(params: Dict[str, Any], request_id: str) -> Dic
     severity = _parse_severity(params.get('severity'))
     age_days = _parse_age_days(params.get('age_days'))
 
-    # Require at least one of version or project_name to scope the query
-    if not version and not project_name:
-        logger.warning(f"[{request_id}] Missing required parameter: neither version nor project_name provided")
-        return {
-            'status': 'error',
-            'type': 'missing_parameter',
-            'retryable': False,
-            'message': (
-                'Please provide at least one of "version" or "project_name" '
-                'to scope the vulnerability query. '
-                'For example: version="2.19" or project_name="OpenSearch".'
-            ),
-        }
-
     logger.info(
         f"[{request_id}] QUERY_VULNERABILITIES: query='{query}', "
         f"version={version}, project_name={project_name}, "
@@ -199,7 +185,7 @@ def handle_query_vulnerabilities(params: Dict[str, Any], request_id: str) -> Dic
             'result_count': 0,
         }
 
-    total_value = hits_envelope['total']['value']
+    total_value = hits_envelope.get('total', {}).get('value', len(hits))
 
     # Log collapse deduplication stats (total is pre-collapse, hits is post-collapse)
     collapsed_count = total_value - len(hits)

--- a/tests/agents/security_advisories/lambda/test_dsl_query_builder.py
+++ b/tests/agents/security_advisories/lambda/test_dsl_query_builder.py
@@ -233,8 +233,8 @@ class TestDSLQueryStructure:
         assert len(filters) == 1
         assert filters[0] == {'term': {'project.tag': 'origin/3.7'}}
 
-    def test_project_name_only_produces_name_and_default_tag_filter(self):
-        """Validates: Requirement 1.4 — project_name alone still gets origin/main default."""
+    def test_project_name_only_produces_name_filter_without_tag(self):
+        """Validates: Requirement 1.4 — project_name alone returns all versions."""
         mock_response = {'hits': {'hits': []}}
         mod, mock_aws = _load_dsl_query_builder(
             mock_opensearch_request=mock_response,
@@ -248,8 +248,7 @@ class TestDSLQueryStructure:
 
         assert 'bool' in body['query']
         filters = body['query']['bool']['filter']
-        assert len(filters) == 2
-        assert {'term': {'project.tag': 'origin/main'}} in filters
+        assert len(filters) == 1
         assert {'term': {'project.name': 'OpenSearch Dashboards'}} in filters
 
     def test_both_params_produce_combined_filter(self):

--- a/tests/agents/security_advisories/test_vulnerabilities_handler.py
+++ b/tests/agents/security_advisories/test_vulnerabilities_handler.py
@@ -295,54 +295,60 @@ class TestCollapseDeduplication:
 
 
 # ---------------------------------------------------------------------------
-# Missing parameter validation
+# Default version behavior
 # ---------------------------------------------------------------------------
 
 
-class TestMissingParameterValidation:
-    """Test that missing version and project_name returns an error."""
+class TestDefaultVersionBehavior:
+    """Test that missing version/project_name defaults to origin/main in the builder."""
 
-    def test_neither_version_nor_project_name_returns_error(self):
-        """When both version and project_name are absent, return missing_parameter error."""
-        mod, mock_dsl = _load_vulnerabilities_handler()
+    def test_neither_version_nor_project_name_defaults_to_origin_main(self):
+        """When both version and project_name are absent, builder defaults to origin/main."""
+        mock_dsl = _make_mock_dsl_query_builder()
+        mock_dsl.query_vulnerabilities.return_value = {'hits': {'hits': []}}
+        mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
             {'query': 'Show all CVEs', '_access_tier': 'privileged'}, 'test-050',
         )
 
-        assert result['status'] == 'error'
-        assert result['type'] == 'missing_parameter'
-        assert result['retryable'] is False
-        assert 'version' in result['message']
-        assert 'project_name' in result['message']
-        # Should NOT have called the query builder
-        mock_dsl.query_vulnerabilities.assert_not_called()
+        # Handler passes through to builder; builder applies origin/main default
+        mock_dsl.query_vulnerabilities.assert_called_once_with(
+            version=None, project_name=None,
+        )
+        assert result['status'] == 'success'
 
-    def test_empty_string_version_and_project_name_returns_error(self):
-        """Empty strings for both version and project_name returns error."""
-        mod, mock_dsl = _load_vulnerabilities_handler()
+    def test_empty_string_version_and_project_name_defaults_to_origin_main(self):
+        """Empty strings for both version and project_name are treated as absent."""
+        mock_dsl = _make_mock_dsl_query_builder()
+        mock_dsl.query_vulnerabilities.return_value = {'hits': {'hits': []}}
+        mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
             {'query': 'Show CVEs', 'version': '', 'project_name': '', '_access_tier': 'privileged'},
             'test-051',
         )
 
-        assert result['status'] == 'error'
-        assert result['type'] == 'missing_parameter'
-        mock_dsl.query_vulnerabilities.assert_not_called()
+        mock_dsl.query_vulnerabilities.assert_called_once_with(
+            version='', project_name='',
+        )
+        assert result['status'] == 'success'
 
-    def test_none_version_and_project_name_returns_error(self):
-        """Explicit None for both version and project_name returns error."""
-        mod, mock_dsl = _load_vulnerabilities_handler()
+    def test_none_version_and_project_name_defaults_to_origin_main(self):
+        """Explicit None for both version and project_name are treated as absent."""
+        mock_dsl = _make_mock_dsl_query_builder()
+        mock_dsl.query_vulnerabilities.return_value = {'hits': {'hits': []}}
+        mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
             {'query': 'Show CVEs', 'version': None, 'project_name': None},
             'test-052',
         )
 
-        assert result['status'] == 'error'
-        assert result['type'] == 'missing_parameter'
-        mock_dsl.query_vulnerabilities.assert_not_called()
+        mock_dsl.query_vulnerabilities.assert_called_once_with(
+            version=None, project_name=None,
+        )
+        assert result['status'] == 'success'
 
     def test_version_provided_passes_validation(self):
         """When version is provided, validation passes."""


### PR DESCRIPTION
### Description
Address PR feedback on DSL query builder

### Issues Resolved
- Harden version classification with a strict two-part regex to avoid misclassifying pre-release strings (e.g., "3.7-rc") as two-part versions
- Catch TypeError in addition to ValueError during semver parsing
- Refactor _connection_error to reuse _error_response for consistent error structure, and log original exception for diagnostics
- Remove handler-level validation requiring version or project_name; when only project_name is provided, return all versions instead of defaulting to origin/main
- Use defensive .get() access for hits total to handle missing keys

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
