### PR TITLE
Resolve three part semver to origin/major.minor branch tag

### DIFF
--- a/agents/security_advisories/action_groups.py
+++ b/agents/security_advisories/action_groups.py
@@ -47,7 +47,8 @@ def _privileged_action_group(
                             type="string",
                             description=(
                                 "OpenSearch version or branch to scope the query. "
-                                "Valid values: a three-part version (e.g., '2.19.6', '3.0.0'), "
+                                "Valid values: a three-part version (e.g., '2.19.6', '3.0.0') "
+                                "which resolves to its branch (origin/major.minor), "
                                 "a two-part branch version (e.g., '3.7', '2.19'), "
                                 "'main', "
                                 "or an origin-prefixed tag (e.g., 'origin/2.19'). "

--- a/agents/security_advisories/lambda/dsl_query_builder.py
+++ b/agents/security_advisories/lambda/dsl_query_builder.py
@@ -65,7 +65,7 @@ def resolve_version_tag(version: str) -> str:
       - Already prefixed with ``"origin/"`` → returned as-is
       - ``"main"`` or ``"latest"`` → ``"origin/main"``
       - Two-part version (e.g., ``"3.7"``) → ``"origin/3.7"`` (branch tag)
-      - Three-part version (e.g., ``"3.7.0"``, ``"2.19.6"``) → returned as-is (release tag)
+      - Three-part version (e.g., ``"3.7.0"``, ``"2.19.6"``) → ``"origin/3.7"``, ``"origin/2.19"`` (branch tag)
       - Non-parseable input → returned as-is (for exact tag lookups)
 
     Args:
@@ -86,8 +86,10 @@ def resolve_version_tag(version: str) -> str:
             logger.info(f"RESOLVE_TAG: '{version}' -> '{resolved}'")
             return resolved
         case 'three_part':
-            logger.info(f"RESOLVE_TAG: '{version}' is a valid semver version, using as-is")
-            return version
+            parsed = semver.Version.parse(version)
+            resolved = f'origin/{parsed.major}.{parsed.minor}'
+            logger.info(f"RESOLVE_TAG: '{version}' -> '{resolved}' (extracted major.minor)")
+            return resolved
         case 'two_part':
             resolved = f'origin/{version}'
             logger.info(f"RESOLVE_TAG: '{version}' -> '{resolved}'")

--- a/tests/agents/security_advisories/lambda/test_dsl_query_builder.py
+++ b/tests/agents/security_advisories/lambda/test_dsl_query_builder.py
@@ -267,8 +267,8 @@ class TestDSLQueryStructure:
         assert 'bool' in body['query']
         filters = body['query']['bool']['filter']
         assert len(filters) == 2
-        # Three-part semver passes through unchanged
-        assert {'term': {'project.tag': '2.19.6'}} in filters
+        # Three-part semver resolves to origin/major.minor
+        assert {'term': {'project.tag': 'origin/2.19'}} in filters
         assert {'term': {'project.name': 'OpenSearch'}} in filters
 
     def test_query_targets_correct_index(self):

--- a/tests/agents/security_advisories/lambda/test_dsl_query_builder_properties.py
+++ b/tests/agents/security_advisories/lambda/test_dsl_query_builder_properties.py
@@ -119,20 +119,21 @@ class TestVersionTagResolutionCorrectness:
 
     @given(version=three_part_versions)
     @settings(max_examples=100)
-    def test_three_part_semver_passes_through_unchanged(self, version):
-        """Three-part valid semver versions pass through unchanged.
+    def test_three_part_semver_maps_to_origin_major_minor(self, version):
+        """Three-part valid semver versions map to origin/{major}.{minor}.
 
         **Validates: Requirements 5.3**
         """
         # Only test versions that are actually valid semver
         try:
-            semver.Version.parse(version)
+            parsed = semver.Version.parse(version)
         except ValueError:
             return
 
         result = resolve_version_tag(version)
-        assert result == version, (
-            f'Three-part semver "{version}" should pass through unchanged, got "{result}"'
+        expected = f'origin/{parsed.major}.{parsed.minor}'
+        assert result == expected, (
+            f'Three-part semver "{version}" should map to "{expected}", got "{result}"'
         )
 
     @given(version=main_latest_variants)

--- a/tests/agents/security_advisories/test_resolve_version_tag.py
+++ b/tests/agents/security_advisories/test_resolve_version_tag.py
@@ -48,15 +48,15 @@ def _load_dsl_query_builder():
 
 
 class TestResolveVersionTagSemver:
-    """Numeric versions are returned as-is for exact release tag lookups."""
+    """Numeric versions resolve to origin/major.minor branch tags."""
 
     def test_three_part_version(self):
         mod = _load_dsl_query_builder()
-        assert mod.resolve_version_tag('3.7.0') == '3.7.0'
+        assert mod.resolve_version_tag('3.7.0') == 'origin/3.7'
 
     def test_three_part_version_with_patch(self):
         mod = _load_dsl_query_builder()
-        assert mod.resolve_version_tag('2.19.6') == '2.19.6'
+        assert mod.resolve_version_tag('2.19.6') == 'origin/2.19'
 
     def test_four_part_version(self):
         """Four-part versions are not a valid user input — treated as non-parseable."""
@@ -70,7 +70,7 @@ class TestResolveVersionTagSemver:
 
     def test_major_zero(self):
         mod = _load_dsl_query_builder()
-        assert mod.resolve_version_tag('0.9.0') == '0.9.0'
+        assert mod.resolve_version_tag('0.9.0') == 'origin/0.9'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Description
Changes the three-part version tag resolution from passing it through as is to resolving to origin/major.minor 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
