### PR TITLE
Add age filtering advisories

### DIFF
--- a/agents/security_advisories/README.md
+++ b/agents/security_advisories/README.md
@@ -50,7 +50,7 @@ Security Advisories Lambda
 | `version` | No | Version to scope the query (e.g., "2.19.6", "3.0.0") |
 | `project_name` | No | Project name to scope the query (e.g., "OpenSearch Dashboards", "OpenSearch") |
 | `severity` | No | Comma-separated severity filter (e.g., "CRITICAL", "CRITICAL,HIGH"). Valid: CRITICAL, HIGH, MEDIUM, LOW |
-| `age_days` | No | Maximum age in days for scan results (e.g., 30 for the past month) |
+| `age_days` | No | Minimum age in days — only return CVEs that have been published for at least this many days (e.g., 60 for release preparation) |
 
 ### list_projects
 

--- a/agents/security_advisories/action_groups.py
+++ b/agents/security_advisories/action_groups.py
@@ -75,9 +75,10 @@ def _privileged_action_group(
                         "age_days": bedrock.CfnAgent.ParameterDetailProperty(
                             type="integer",
                             description=(
-                                "Maximum age in days for scan results. Only return "
-                                "vulnerabilities from scans within this many days "
-                                "(e.g., 30 for the past month, 7 for the past week)"
+                                "Minimum age in days of CVE advisories to include. "
+                                "Only return CVEs published at least this many days ago "
+                                "(e.g., 60 for advisories older than 60 days, 14 for 2 weeks). "
+                                "Default to 60 for release preparation queries."
                             ),
                             required=False,
                         ),

--- a/agents/security_advisories/instructions.py
+++ b/agents/security_advisories/instructions.py
@@ -67,7 +67,7 @@ If the user does NOT specify a version or tag (e.g., "CVEs for OpenSearch"), def
 | `version` | No | Version to scope the query (e.g., "2.19.6") |
 | `project_name` | No | Project name to scope the query (e.g., "OpenSearch Dashboards") |
 | `severity` | No | Comma-separated severity filter applied to results (e.g., "CRITICAL", "CRITICAL,HIGH"). Valid values: CRITICAL, HIGH, MEDIUM, LOW |
-| `age_days` | No | Maximum age in days for scan results. Only scans within this window are returned (e.g., 30 for the past month) |
+| `age_days` | No | Integer minimum age in days — only return CVEs published at least this many days ago. Extract from phrases like "older than 60 days" → age_days=60, "2 weeks" → age_days=14. Default to 60 for release prep queries. |
 
 ## HANDLING AMBIGUOUS VERSION QUERIES
 When the user's query contains vague version language ("most recent", "latest", "newest", "current") instead of a concrete tag or version number:
@@ -86,8 +86,6 @@ NOTE: In all examples below, the agent MUST call `list_projects()` first to reso
 
 - "Show me all CVEs for 2.19.6" → query_vulnerabilities(query="Show me all CVEs for 2.19.6", version="2.19.6") — no project_name needed, returns CVEs across all projects for that version
 - "High severity CVEs for Dashboards" → FIRST list_projects() to resolve "Dashboards" to the canonical name, THEN query_vulnerabilities(query="High severity CVEs for Dashboards", project_name=<canonical name from list_projects>, severity="HIGH", version="origin/main")
-- "Critical vulnerabilities in the past 30 days" → query_vulnerabilities(query="Critical vulnerabilities in the past 30 days", severity="CRITICAL", age_days="30", version="origin/main")
-- "Critical and high CVEs for OpenSearch 3.0.0 from the last week" → FIRST list_projects() to confirm "OpenSearch" is a valid canonical name, THEN query_vulnerabilities(query="Critical and high CVEs for OpenSearch 3.0.0 from the last week", version="3.0.0", project_name=<canonical name from list_projects>, severity="CRITICAL,HIGH", age_days="7")
 - "CVEs for OpenSearch Dashboards most recent release" → FIRST list_projects(), THEN present available tags and ask which one the user wants, THEN query_vulnerabilities with the user's choice
 - "Show me CVEs for 3.7" → query_vulnerabilities(query="Show me CVEs for 3.7", version="origin/3.7")
 - "Show me CVEs for origin/3.7" → query_vulnerabilities(query="Show me CVEs for origin/3.7", version="origin/3.7")

--- a/agents/security_advisories/lambda/dsl_query_builder.py
+++ b/agents/security_advisories/lambda/dsl_query_builder.py
@@ -175,6 +175,8 @@ def _execute_query(index: str, query_body: str) -> Dict[str, Any]:
 
     # Log truncation warning when total hits exceed the returned count
     hits = result.get('hits', {}) if isinstance(result, dict) else {}
+    if not isinstance(hits, dict):
+        hits = {}
     total_hits = hits.get('total', {}).get('value', 0)
     returned_count = len(hits.get('hits', []))
     if total_hits > returned_count:

--- a/agents/security_advisories/lambda/dsl_query_builder.py
+++ b/agents/security_advisories/lambda/dsl_query_builder.py
@@ -18,7 +18,7 @@ import json
 import logging
 import re
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import semver
 from aws_utils import get_latest_scans_index, opensearch_request
@@ -329,7 +329,7 @@ def query_advisories(
     cve_ids: List[str],
     age_days: Optional[int] = None,
     severity: Optional[Set[str]] = None,
-) -> Set[str]:
+) -> Tuple[Set[str], bool]:
     """Query the advisories index to filter CVEs by age and/or severity.
 
     Constructs a bool/filter query that:
@@ -352,10 +352,12 @@ def query_advisories(
             If None, no severity filter is applied.
 
     Returns:
-        A set of CVE IDs matching the specified criteria.
+        A tuple of (matched_cve_ids, is_partial) where matched_cve_ids is the
+        set of CVE IDs matching the specified criteria, and is_partial is True
+        if one or more query batches failed (meaning results may be incomplete).
     """
     if (not cve_ids) or (not age_days and not severity):
-        return set()
+        return set(), False
 
     # Calculate the cutoff date if age filtering is requested
     cutoff_iso = None
@@ -368,6 +370,7 @@ def query_advisories(
     unique_ids = list(set(cve_ids))
 
     matched_cve_ids: Set[str] = set()
+    is_partial = False
 
     # Batch the terms query to avoid hitting OpenSearch limits
     for i in range(0, len(unique_ids), _ADVISORIES_BATCH_SIZE):
@@ -401,8 +404,9 @@ def query_advisories(
             logger.error(
                 f'SECURITY_ADVISORIES_ADVISORIES_QUERY_FAILED: {error_msg}',
             )
-            # Return what we have so far rather than failing entirely
-            return matched_cve_ids
+            # Mark results as partial and continue with remaining batches
+            is_partial = True
+            continue
 
         hits = result.get('hits', {}).get('hits', [])
 
@@ -413,7 +417,8 @@ def query_advisories(
                     matched_cve_ids.add(alias)
 
     logger.info(
-        f'ADVISORIES_QUERY: Found {len(matched_cve_ids)} matching CVE(s)',
+        f'ADVISORIES_QUERY: Found {len(matched_cve_ids)} matching CVE(s)'
+        f'{" (partial results due to batch failure)" if is_partial else ""}',
     )
 
-    return matched_cve_ids
+    return matched_cve_ids, is_partial

--- a/agents/security_advisories/lambda/dsl_query_builder.py
+++ b/agents/security_advisories/lambda/dsl_query_builder.py
@@ -92,7 +92,7 @@ def resolve_version_tag(version: str) -> str:
         case _:
             resolved = version
 
-    logger.debug(f"RESOLVE_TAG: '{version}' -> '{resolved}'")
+    logger.info(f"RESOLVE_TAG: '{version}' -> '{resolved}'")
     return resolved
 
 

--- a/agents/security_advisories/lambda/dsl_query_builder.py
+++ b/agents/security_advisories/lambda/dsl_query_builder.py
@@ -173,13 +173,15 @@ def _execute_query(index: str, query_body: str) -> Dict[str, Any]:
 
     result = opensearch_request('GET', path, body=query_body)
 
-    # Log truncation warning when result count equals the configured size
-    hits = result.get('hits') if isinstance(result, dict) else None
-    documents = hits.get('hits', []) if isinstance(hits, dict) else []
-    if len(documents) == _DEFAULT_QUERY_SIZE:
+    # Log truncation warning when total hits exceed the returned count
+    hits = result.get('hits', {}) if isinstance(result, dict) else {}
+    total_hits = hits.get('total', {}).get('value', 0)
+    returned_count = len(hits.get('hits', []))
+    if total_hits > returned_count:
         logger.warning(
-            f'DSL_QUERY: results may be truncated — '
-            f'returned {_DEFAULT_QUERY_SIZE} documents (equals size limit of {_DEFAULT_QUERY_SIZE})',
+            f'DSL_QUERY: results truncated — '
+            f'returned {returned_count} of {total_hits} total hits '
+            f'(size limit: {_DEFAULT_QUERY_SIZE})',
         )
 
     return result

--- a/agents/security_advisories/lambda/dsl_query_builder.py
+++ b/agents/security_advisories/lambda/dsl_query_builder.py
@@ -11,12 +11,14 @@ relied on an ML-powered pipeline for NL→DSL translation.
 Functions:
     resolve_version_tag: Map user-provided version to canonical tag format
     query_vulnerabilities: Construct and execute a DSL query for vulnerability scans
+    query_advisories: Query advisories index to filter CVEs by age and/or severity
 """
 
 import json
 import logging
 import re
-from typing import Any, Dict, Optional
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Set
 
 import semver
 from aws_utils import get_latest_scans_index, opensearch_request
@@ -79,24 +81,19 @@ def resolve_version_tag(version: str) -> str:
 
     match _classify_version(version):
         case 'origin_prefixed':
-            logger.info(f"RESOLVE_TAG: '{version}' already has origin/ prefix, using as-is")
-            return version
+            resolved = version
         case 'main_alias':
             resolved = 'origin/main'
-            logger.info(f"RESOLVE_TAG: '{version}' -> '{resolved}'")
-            return resolved
         case 'three_part':
             parsed = semver.Version.parse(version)
             resolved = f'origin/{parsed.major}.{parsed.minor}'
-            logger.info(f"RESOLVE_TAG: '{version}' -> '{resolved}' (extracted major.minor)")
-            return resolved
         case 'two_part':
             resolved = f'origin/{version}'
-            logger.info(f"RESOLVE_TAG: '{version}' -> '{resolved}'")
-            return resolved
         case _:
-            logger.info(f"RESOLVE_TAG: Cannot parse '{version}', using as-is")
-            return version
+            resolved = version
+
+    logger.debug(f"RESOLVE_TAG: '{version}' -> '{resolved}'")
+    return resolved
 
 
 def _build_dsl_query(
@@ -170,9 +167,6 @@ def _execute_query(index: str, query_body: str) -> Dict[str, Any]:
         Exception: If the request fails (non-2xx, connection error, etc.).
     """
     path = f'/{index}/_search'
-
-    logger.info(f'DSL_QUERY: GET {path}')
-    logger.info(f'DSL_QUERY: body={query_body}')
 
     result = opensearch_request('GET', path, body=query_body)
 
@@ -315,3 +309,103 @@ def query_vulnerabilities(
         return _connection_error(e)
 
     return result
+
+
+# --- Advisories Index Query ---
+
+# The advisories alias points to the current advisories index.
+_ADVISORIES_INDEX = 'advisories'
+
+# Maximum number of advisory IDs to query in a single terms lookup.
+# OpenSearch has a default max_terms_count of 65536; we use a conservative
+# batch size to stay well within limits and avoid oversized payloads.
+_ADVISORIES_BATCH_SIZE = 1000
+
+
+def query_advisories(
+    cve_ids: List[str],
+    age_days: Optional[int] = None,
+    severity: Optional[Set[str]] = None,
+) -> Set[str]:
+    """Query the advisories index to filter CVEs by age and/or severity.
+
+    Constructs a bool/filter query that:
+      1. Matches advisory documents whose ``id`` is in the provided CVE ID list.
+      2. Optionally filters to those with ``timestamp.publish`` older than the
+         cutoff date (when ``age_days`` is provided).
+      3. Optionally filters by severity level(s) (when ``severity`` is provided).
+
+    At least one of ``age_days`` or ``severity`` must be specified for this
+    function to execute a query. If neither is provided, returns an empty set.
+
+    Args:
+        cve_ids: List of CVE/advisory identifiers to look up.
+        age_days: Minimum age in days. Only advisories published at least this
+            many days ago will be returned. If None, no age filter is applied.
+        severity: Optional set of severity levels to filter on (e.g., {"HIGH", "CRITICAL"}).
+            If None, no severity filter is applied.
+
+    Returns:
+        A set of CVE IDs matching the specified criteria.
+    """
+    if (not cve_ids) or (not age_days and not severity):
+        return set()
+
+    # Calculate the cutoff date if age filtering is requested
+    cutoff_iso = None
+    if age_days and age_days > 0:
+        now = datetime.now(timezone.utc)
+        cutoff = now - timedelta(days=age_days)
+        cutoff_iso = cutoff.strftime('%Y-%m-%dT%H:%M:%S.000Z')
+
+    # Deduplicate input IDs
+    unique_ids = list(set(cve_ids))
+
+    matched_cve_ids: Set[str] = set()
+
+    # Batch the terms query to avoid hitting OpenSearch limits
+    for i in range(0, len(unique_ids), _ADVISORIES_BATCH_SIZE):
+        batch = unique_ids[i:i + _ADVISORIES_BATCH_SIZE]
+
+        filter_clauses: List[Dict[str, Any]] = [
+            {'terms': {'id': batch}},
+        ]
+
+        if cutoff_iso:
+            filter_clauses.append({'range': {'timestamp.publish': {'lte': cutoff_iso}}})
+
+        if severity:
+            filter_clauses.append({'terms': {'severity': list(severity)}})
+
+        query_body = json.dumps({
+            'size': len(batch),
+            '_source': ['id'],
+            'query': {
+                'bool': {
+                    'filter': filter_clauses,
+                },
+            },
+        })
+
+        try:
+            result = _execute_query(_ADVISORIES_INDEX, query_body)
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(
+                f'SECURITY_ADVISORIES_ADVISORIES_QUERY_FAILED: {error_msg}',
+            )
+            # Return what we have so far rather than failing entirely
+            return matched_cve_ids
+
+        hits = result.get('hits', {}).get('hits', [])
+
+        for hit in hits:
+            advisory_id = hit.get('_source', {}).get('id')
+            if advisory_id:
+                matched_cve_ids.add(advisory_id)
+
+    logger.info(
+        f'ADVISORIES_QUERY: Found {len(matched_cve_ids)} matching CVE(s)',
+    )
+
+    return matched_cve_ids

--- a/agents/security_advisories/lambda/dsl_query_builder.py
+++ b/agents/security_advisories/lambda/dsl_query_builder.py
@@ -168,6 +168,9 @@ def _execute_query(index: str, query_body: str) -> Dict[str, Any]:
     """
     path = f'/{index}/_search'
 
+    logger.info(f'DSL_QUERY: GET {path}')
+    logger.info(f'DSL_QUERY: body={query_body}')
+
     result = opensearch_request('GET', path, body=query_body)
 
     # Log truncation warning when result count equals the configured size

--- a/agents/security_advisories/lambda/dsl_query_builder.py
+++ b/agents/security_advisories/lambda/dsl_query_builder.py
@@ -333,7 +333,10 @@ def query_advisories(
     """Query the advisories index to filter CVEs by age and/or severity.
 
     Constructs a bool/filter query that:
-      1. Matches advisory documents whose ``id`` is in the provided CVE ID list.
+      1. Matches advisory documents whose ``aliases`` field contains any of
+         the provided CVE IDs. This is more resilient than matching on ``id``
+         because advisory re-keying can change the ``id`` while ``aliases``
+         retains all known identifiers.
       2. Optionally filters to those with ``timestamp.publish`` older than the
          cutoff date (when ``age_days`` is provided).
       3. Optionally filters by severity level(s) (when ``severity`` is provided).
@@ -369,9 +372,10 @@ def query_advisories(
     # Batch the terms query to avoid hitting OpenSearch limits
     for i in range(0, len(unique_ids), _ADVISORIES_BATCH_SIZE):
         batch = unique_ids[i:i + _ADVISORIES_BATCH_SIZE]
+        batch_set = set(batch)
 
         filter_clauses: List[Dict[str, Any]] = [
-            {'terms': {'id': batch}},
+            {'terms': {'aliases': batch}},
         ]
 
         if cutoff_iso:
@@ -382,7 +386,7 @@ def query_advisories(
 
         query_body = json.dumps({
             'size': len(batch),
-            '_source': ['id'],
+            '_source': ['aliases'],
             'query': {
                 'bool': {
                     'filter': filter_clauses,
@@ -403,9 +407,10 @@ def query_advisories(
         hits = result.get('hits', {}).get('hits', [])
 
         for hit in hits:
-            advisory_id = hit.get('_source', {}).get('id')
-            if advisory_id:
-                matched_cve_ids.add(advisory_id)
+            aliases = hit.get('_source', {}).get('aliases', [])
+            for alias in aliases:
+                if alias in batch_set:
+                    matched_cve_ids.add(alias)
 
     logger.info(
         f'ADVISORIES_QUERY: Found {len(matched_cve_ids)} matching CVE(s)',

--- a/agents/security_advisories/lambda/response_filter.py
+++ b/agents/security_advisories/lambda/response_filter.py
@@ -6,7 +6,7 @@
 Post-query filtering for vulnerability results.
 
 Handles array-level filtering that can't be efficiently done in OpenSearch:
-severity, exclusion status, and specific CVE lookups.
+exclusion removal, allowlist-based filtering, and advisory URL enrichment.
 """
 
 import logging
@@ -31,15 +31,20 @@ def _build_advisory_url(vuln_id: str) -> str:
 
 def filter_vulnerabilities(
     vulnerabilities: List[Dict[str, Any]],
-    severity: Optional[Set[str]] = None,
+    allowed_cve_ids: Optional[Set[str]] = None,
     include_excluded: bool = False,
 ) -> List[Dict[str, Any]]:
-    """Filter a vulnerabilities array from a scan document.
+    """Remove excluded CVEs, apply an optional allowlist, and enrich with advisory URLs.
+
+    This function handles post-query filtering that cannot be done at the
+    OpenSearch level: exclusion removal and allowlist-based filtering (when
+    severity/age filtering has been resolved into a set of CVE IDs by
+    ``query_advisories``).
 
     Args:
         vulnerabilities: Raw vulnerabilities array from the scan document.
-        severity: Set of severity levels to include (e.g., {"HIGH", "CRITICAL"}).
-                  If None, all severities are included.
+        allowed_cve_ids: If provided, only retain vulnerabilities whose ID is
+            in this set. When ``None``, no allowlist filtering is applied.
         include_excluded: If False (default), only return open (non-excluded) CVEs.
 
     Returns:
@@ -53,8 +58,8 @@ def filter_vulnerabilities(
         if not include_excluded and vuln.get("excluded"):
             continue
 
-        # Severity filter
-        if severity and vuln.get("severity") not in severity:
+        # Allowlist filter
+        if allowed_cve_ids is not None and vuln.get("id") not in allowed_cve_ids:
             continue
 
         # Enrich with advisory link

--- a/agents/security_advisories/lambda/vulnerabilities_handler.py
+++ b/agents/security_advisories/lambda/vulnerabilities_handler.py
@@ -117,22 +117,15 @@ def _process_hits(
 
         raw_vulns = source.get('vulnerabilities', [])
 
-        if allowed_cve_ids is not None:
-            # Advisories-based filtering: keep only non-excluded CVEs in the allowlist
-            filtered_vulns = filter_vulnerabilities(raw_vulns, severity=None)
-            pre_allowlist_count = len(filtered_vulns)
-            filtered_vulns = [
-                v for v in filtered_vulns if v.get('id') in allowed_cve_ids
-            ]
-            if pre_allowlist_count > 0 or len(filtered_vulns) > 0:
-                logger.info(
-                    f"[{request_id}] PROCESS_HITS: project={project.get('name')}, "
-                    f"raw={len(raw_vulns)}, after_exclusion_filter={pre_allowlist_count}, "
-                    f"after_advisories_filter={len(filtered_vulns)}",
-                )
-        else:
-            # No severity/age filter — just remove excluded CVEs
-            filtered_vulns = filter_vulnerabilities(raw_vulns, severity=None)
+        filtered_vulns = filter_vulnerabilities(
+            raw_vulns, allowed_cve_ids=allowed_cve_ids,
+        )
+
+        if allowed_cve_ids is not None and (len(raw_vulns) > 0 or len(filtered_vulns) > 0):
+            logger.info(
+                f"[{request_id}] PROCESS_HITS: project={project.get('name')}, "
+                f"raw={len(raw_vulns)}, after_filter={len(filtered_vulns)}",
+            )
 
         trimmed_vulns = [
             {k: v for k, v in vuln.items() if k in _VULN_SUMMARY_FIELDS}

--- a/agents/security_advisories/lambda/vulnerabilities_handler.py
+++ b/agents/security_advisories/lambda/vulnerabilities_handler.py
@@ -241,6 +241,7 @@ def handle_query_vulnerabilities(params: Dict[str, Any], request_id: str) -> Dic
     # advisories index to get the authoritative set of CVE IDs matching those
     # criteria. This single allowlist replaces separate application-side filters.
     allowed_cve_ids = None
+    advisories_partial = False
     if severity or age_days:
         # Collect all CVE IDs across all scan hits
         all_cve_ids = []
@@ -252,7 +253,9 @@ def handle_query_vulnerabilities(params: Dict[str, Any], request_id: str) -> Dic
                     all_cve_ids.append(vuln_id)
 
         if all_cve_ids:
-            allowed_cve_ids = query_advisories(all_cve_ids, age_days=age_days, severity=severity)
+            allowed_cve_ids, advisories_partial = query_advisories(
+                all_cve_ids, age_days=age_days, severity=severity,
+            )
             logger.info(
                 f"[{request_id}] ADVISORIES_FILTER: {len(allowed_cve_ids)} of "
                 f"{len(set(all_cve_ids))} unique CVE(s) match criteria "
@@ -286,6 +289,12 @@ def handle_query_vulnerabilities(params: Dict[str, Any], request_id: str) -> Dic
         'results': results,
         'neglected_page_url': neglected_url,
     }
+
+    if advisories_partial:
+        result['advisory_filter_warning'] = (
+            "Some advisory lookups failed. The severity/age filter results "
+            "shown may be incomplete — some matching CVEs could be missing."
+        )
 
     if results_truncated:
         result['truncation_message'] = (

--- a/agents/security_advisories/lambda/vulnerabilities_handler.py
+++ b/agents/security_advisories/lambda/vulnerabilities_handler.py
@@ -236,6 +236,10 @@ def handle_query_vulnerabilities(params: Dict[str, Any], request_id: str) -> Dic
     allowed_cve_ids = None
     advisories_partial = False
     if severity or age_days:
+        # Initialize to empty set so the filter intent is preserved even when
+        # no CVE IDs are found across scan hits (avoids falling back to "no filter").
+        allowed_cve_ids = set()
+
         # Collect all CVE IDs across all scan hits
         all_cve_ids = []
         for hit in hits:

--- a/agents/security_advisories/lambda/vulnerabilities_handler.py
+++ b/agents/security_advisories/lambda/vulnerabilities_handler.py
@@ -15,8 +15,8 @@ Functions:
 import logging
 from typing import Any, Dict, Optional, Set
 
-from dsl_query_builder import (_DEFAULT_QUERY_SIZE, query_vulnerabilities,
-                               resolve_version_tag)
+from dsl_query_builder import (_DEFAULT_QUERY_SIZE, query_advisories,
+                               query_vulnerabilities, resolve_version_tag)
 from response_filter import (build_neglected_page_url, build_summary,
                              filter_vulnerabilities)
 
@@ -82,21 +82,29 @@ def _map_age_days_to_age(age_days: Optional[int]) -> Optional[str]:
 
 
 def _process_hits(
-    hits: list, severity: Optional[Set[str]], request_id: str,
+    hits: list,
+    request_id: str,
+    allowed_cve_ids: Optional[Set[str]] = None,
 ) -> list:
     """Process raw search hits into filtered, trimmed result entries.
 
     Each hit represents a distinct project from the latest scan index.
     The DSL query uses ``collapse`` on ``project.name`` to return only
     the most recent scan document per project, so no application-level
-    deduplication is needed. Filtering is applied at the vulnerability
-    level (severity, exclusion status) and results are trimmed to
-    essential fields to reduce payload size.
+    deduplication is needed.
+
+    When ``allowed_cve_ids`` is provided (from the advisories index query),
+    only vulnerabilities whose ID is in that set are retained. This handles
+    both severity and age filtering via a single allowlist.
+
+    When ``allowed_cve_ids`` is None (no severity or age filter), only
+    exclusion filtering is applied (removing excluded CVEs).
 
     Args:
         hits: Hit list from the DSL query response (already deduplicated via collapse).
-        severity: Set of severity levels to retain, or ``None`` for all.
         request_id: Short request ID for log correlation.
+        allowed_cve_ids: If provided, only retain vulnerabilities whose ID is in
+            this set. Used when severity and/or age filtering is active.
 
     Returns:
         List of structured result dicts ready for the response payload.
@@ -108,20 +116,44 @@ def _process_hits(
         timestamp = source.get('timestamp', {})
 
         raw_vulns = source.get('vulnerabilities', [])
-        filtered_vulns = filter_vulnerabilities(raw_vulns, severity=severity)
+
+        if allowed_cve_ids is not None:
+            # Advisories-based filtering: keep only non-excluded CVEs in the allowlist
+            filtered_vulns = filter_vulnerabilities(raw_vulns, severity=None)
+            pre_allowlist_count = len(filtered_vulns)
+            filtered_vulns = [
+                v for v in filtered_vulns if v.get('id') in allowed_cve_ids
+            ]
+            if pre_allowlist_count > 0 or len(filtered_vulns) > 0:
+                logger.info(
+                    f"[{request_id}] PROCESS_HITS: project={project.get('name')}, "
+                    f"raw={len(raw_vulns)}, after_exclusion_filter={pre_allowlist_count}, "
+                    f"after_advisories_filter={len(filtered_vulns)}",
+                )
+        else:
+            # No severity/age filter — just remove excluded CVEs
+            filtered_vulns = filter_vulnerabilities(raw_vulns, severity=None)
+
         trimmed_vulns = [
             {k: v for k, v in vuln.items() if k in _VULN_SUMMARY_FIELDS}
             for vuln in filtered_vulns
         ]
 
-        results.append({
+        entry = {
             'project': project,
             'timestamp': timestamp,
-            'total_count': source.get('count', {}),
             'filtered_vulnerabilities': trimmed_vulns,
             'filtered_count': len(trimmed_vulns),
             'severity_summary': build_summary(filtered_vulns),
-        })
+        }
+
+        # Only include total_count when advisories filtering is NOT active.
+        # When filtering is active the total scan counts are misleading
+        # because they reflect the full scan, not the filtered subset.
+        if allowed_cve_ids is None:
+            entry['total_count'] = source.get('count', {})
+
+        results.append(entry)
     return results
 
 
@@ -131,13 +163,18 @@ def handle_query_vulnerabilities(params: Dict[str, Any], request_id: str) -> Dic
     Extracts query parameters, executes a structured DSL query against the
     scans index, and post-processes results with severity/exclusion/age filtering.
 
+    When ``age_days`` is provided, performs a secondary query against the
+    advisories index to identify CVEs whose ``timestamp.publish`` is older
+    than the specified threshold. Only those CVEs are retained in the results.
+
     Args:
         params: Parameters dict containing:
             - query (str): Natural language query (required).
             - version (str, optional): Version to scope the query.
             - project_name (str, optional): Project name to scope the query.
             - severity (str, optional): Comma-separated severity levels.
-            - age_days (str, optional): Max age in days for scan results.
+            - age_days (str, optional): Minimum age in days — only return CVEs
+              published at least this many days ago.
         request_id: Short request ID for log correlation.
 
     Returns:
@@ -200,8 +237,30 @@ def handle_query_vulnerabilities(params: Dict[str, Any], request_id: str) -> Dic
     # query size limit, meaning there may be more unique projects than returned.
     results_truncated = len(hits) >= _DEFAULT_QUERY_SIZE
 
+    # Advisories filtering: when severity or age_days is specified, query the
+    # advisories index to get the authoritative set of CVE IDs matching those
+    # criteria. This single allowlist replaces separate application-side filters.
+    allowed_cve_ids = None
+    if severity or age_days:
+        # Collect all CVE IDs across all scan hits
+        all_cve_ids = []
+        for hit in hits:
+            vulns = hit.get('_source', {}).get('vulnerabilities', [])
+            for vuln in vulns:
+                vuln_id = vuln.get('id')
+                if vuln_id:
+                    all_cve_ids.append(vuln_id)
+
+        if all_cve_ids:
+            allowed_cve_ids = query_advisories(all_cve_ids, age_days=age_days, severity=severity)
+            logger.info(
+                f"[{request_id}] ADVISORIES_FILTER: {len(allowed_cve_ids)} of "
+                f"{len(set(all_cve_ids))} unique CVE(s) match criteria "
+                f"(severity={severity}, age_days={age_days})",
+            )
+
     # Process each scan document hit
-    results = _process_hits(hits, severity, request_id)
+    results = _process_hits(hits, request_id, allowed_cve_ids=allowed_cve_ids)
 
     logger.info(f"[{request_id}] Returning {len(results)} result entries")
 

--- a/tests/agents/security_advisories/lambda/test_dsl_query_builder.py
+++ b/tests/agents/security_advisories/lambda/test_dsl_query_builder.py
@@ -11,6 +11,7 @@ Validates: Requirements 1.4, 1.7, 3.2
 
 import importlib
 import json
+import logging
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -515,3 +516,64 @@ class TestMalformedResponse:
         result = mod.query_vulnerabilities(version='3.7')
 
         assert 'status' not in result
+
+
+# ---------------------------------------------------------------------------
+# Test: Truncation warning logged when total hits exceed returned count
+# ---------------------------------------------------------------------------
+
+
+class TestTruncationWarning:
+    """Test that a warning is logged when results are truncated."""
+
+    def test_warning_logged_when_total_exceeds_returned(self, caplog):
+        """Validates: truncation warning uses hits.total.value."""
+        mock_response = {
+            'hits': {
+                'total': {'value': 2500, 'relation': 'eq'},
+                'hits': [{'_id': f'doc-{i}'} for i in range(1000)],
+            },
+        }
+        mod, _ = _load_dsl_query_builder(
+            mock_opensearch_request=mock_response,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            mod.query_vulnerabilities(version='3.7')
+
+        assert any('results truncated' in record.message for record in caplog.records)
+        assert any('returned 1000 of 2500 total hits' in record.message for record in caplog.records)
+
+    def test_no_warning_when_all_results_returned(self, caplog):
+        """Validates: no warning when total equals returned count."""
+        mock_response = {
+            'hits': {
+                'total': {'value': 5, 'relation': 'eq'},
+                'hits': [{'_id': f'doc-{i}'} for i in range(5)],
+            },
+        }
+        mod, _ = _load_dsl_query_builder(
+            mock_opensearch_request=mock_response,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            mod.query_vulnerabilities(version='3.7')
+
+        assert not any('truncated' in record.message for record in caplog.records)
+
+    def test_no_warning_when_zero_results(self, caplog):
+        """Validates: no warning when zero results."""
+        mock_response = {
+            'hits': {
+                'total': {'value': 0, 'relation': 'eq'},
+                'hits': [],
+            },
+        }
+        mod, _ = _load_dsl_query_builder(
+            mock_opensearch_request=mock_response,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            mod.query_vulnerabilities(version='3.7')
+
+        assert not any('truncated' in record.message for record in caplog.records)

--- a/tests/agents/security_advisories/lambda/test_dsl_query_builder.py
+++ b/tests/agents/security_advisories/lambda/test_dsl_query_builder.py
@@ -577,3 +577,409 @@ class TestTruncationWarning:
             mod.query_vulnerabilities(version='3.7')
 
         assert not any('truncated' in record.message for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Test: query_advisories — aliases extraction, batching, partial results
+# ---------------------------------------------------------------------------
+
+
+class TestQueryAdvisoriesBasicBehavior:
+    """Test query_advisories early-return conditions and basic behavior."""
+
+    def test_empty_cve_ids_returns_empty_set(self):
+        """Empty input list returns empty set immediately without querying."""
+        mod, mock_aws = _load_dsl_query_builder()
+
+        result, is_partial = mod.query_advisories(cve_ids=[], age_days=30)
+
+        assert result == set()
+        assert is_partial is False
+        # No query should have been made
+        mock_aws.opensearch_request.assert_not_called()
+
+    def test_no_filter_criteria_returns_empty_set(self):
+        """When neither age_days nor severity is provided, returns empty set."""
+        mod, mock_aws = _load_dsl_query_builder()
+
+        result, is_partial = mod.query_advisories(
+            cve_ids=['CVE-2024-0001'],
+            age_days=None,
+            severity=None,
+        )
+
+        assert result == set()
+        assert is_partial is False
+        mock_aws.opensearch_request.assert_not_called()
+
+    def test_zero_age_days_no_severity_returns_empty_set(self):
+        """age_days=0 is falsy, so without severity, returns empty set."""
+        mod, mock_aws = _load_dsl_query_builder()
+
+        result, is_partial = mod.query_advisories(
+            cve_ids=['CVE-2024-0001'],
+            age_days=0,
+            severity=None,
+        )
+
+        assert result == set()
+        assert is_partial is False
+        mock_aws.opensearch_request.assert_not_called()
+
+
+class TestQueryAdvisoriesAliasesExtraction:
+    """Test that aliases from hits are correctly matched to input CVE IDs."""
+
+    def test_single_cve_matched_via_aliases(self):
+        """A hit with aliases containing the queried CVE is returned."""
+        mock_response = {
+            'hits': {
+                'hits': [
+                    {
+                        '_source': {
+                            'aliases': ['CVE-2024-0001', 'GHSA-xxxx-yyyy-zzzz'],
+                        },
+                    },
+                ],
+            },
+        }
+        mod, _ = _load_dsl_query_builder(mock_opensearch_request=mock_response)
+
+        result, is_partial = mod.query_advisories(
+            cve_ids=['CVE-2024-0001'],
+            age_days=30,
+        )
+
+        assert result == {'CVE-2024-0001'}
+        assert is_partial is False
+
+    def test_multiple_cves_matched_via_aliases(self):
+        """Multiple CVEs matched across different hits."""
+        mock_response = {
+            'hits': {
+                'hits': [
+                    {
+                        '_source': {
+                            'aliases': ['CVE-2024-0001', 'GHSA-aaaa-bbbb-cccc'],
+                        },
+                    },
+                    {
+                        '_source': {
+                            'aliases': ['CVE-2024-0003'],
+                        },
+                    },
+                ],
+            },
+        }
+        mod, _ = _load_dsl_query_builder(mock_opensearch_request=mock_response)
+
+        result, is_partial = mod.query_advisories(
+            cve_ids=['CVE-2024-0001', 'CVE-2024-0002', 'CVE-2024-0003'],
+            age_days=90,
+        )
+
+        # CVE-2024-0002 is not in any aliases, so not returned
+        assert result == {'CVE-2024-0001', 'CVE-2024-0003'}
+        assert is_partial is False
+
+    def test_alias_not_in_batch_is_ignored(self):
+        """Aliases in the hit that are not in the queried batch are not returned."""
+        mock_response = {
+            'hits': {
+                'hits': [
+                    {
+                        '_source': {
+                            'aliases': ['CVE-2024-0001', 'CVE-2024-9999'],
+                        },
+                    },
+                ],
+            },
+        }
+        mod, _ = _load_dsl_query_builder(mock_opensearch_request=mock_response)
+
+        result, is_partial = mod.query_advisories(
+            cve_ids=['CVE-2024-0001'],
+            age_days=30,
+        )
+
+        # Only CVE-2024-0001 was queried, so CVE-2024-9999 is not included
+        assert result == {'CVE-2024-0001'}
+        assert is_partial is False
+
+    def test_no_matching_aliases_returns_empty_set(self):
+        """If no aliases match the queried IDs, returns empty set."""
+        mock_response = {
+            'hits': {
+                'hits': [
+                    {
+                        '_source': {
+                            'aliases': ['CVE-2024-9999', 'GHSA-xxxx-yyyy-zzzz'],
+                        },
+                    },
+                ],
+            },
+        }
+        mod, _ = _load_dsl_query_builder(mock_opensearch_request=mock_response)
+
+        result, is_partial = mod.query_advisories(
+            cve_ids=['CVE-2024-0001'],
+            age_days=30,
+        )
+
+        assert result == set()
+        assert is_partial is False
+
+    def test_deduplicates_input_cve_ids(self):
+        """Duplicate CVE IDs in input are deduplicated before querying."""
+        mock_response = {
+            'hits': {
+                'hits': [
+                    {
+                        '_source': {
+                            'aliases': ['CVE-2024-0001'],
+                        },
+                    },
+                ],
+            },
+        }
+        mod, mock_aws = _load_dsl_query_builder(mock_opensearch_request=mock_response)
+
+        result, is_partial = mod.query_advisories(
+            cve_ids=['CVE-2024-0001', 'CVE-2024-0001', 'CVE-2024-0001'],
+            age_days=30,
+        )
+
+        assert result == {'CVE-2024-0001'}
+        assert is_partial is False
+        # Only one query should be made (1 unique ID, fits in one batch)
+        assert mock_aws.opensearch_request.call_count == 1
+
+
+class TestQueryAdvisoriesBatchFailure:
+    """Test is_partial flag when batch queries fail."""
+
+    def test_single_batch_failure_sets_is_partial(self):
+        """When the only batch fails, is_partial=True and result is empty."""
+        mod, _ = _load_dsl_query_builder(
+            mock_opensearch_request=Exception('OpenSearch request failed: 500 - Internal Server Error'),
+        )
+
+        result, is_partial = mod.query_advisories(
+            cve_ids=['CVE-2024-0001'],
+            age_days=30,
+        )
+
+        assert result == set()
+        assert is_partial is True
+
+    def test_partial_batch_failure_continues_processing(self):
+        """When one batch fails and another succeeds, results are partial."""
+        call_count = [0]
+
+        def mock_execute_query(index, query_body):
+            """First call raises, second call returns a hit matching one of the batch IDs."""
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx == 0:
+                raise Exception('Connection timeout')
+            # Return a hit whose alias matches the first ID in this batch
+            import json as _json
+            body = _json.loads(query_body)
+            batch_ids = body['query']['bool']['filter'][0]['terms']['aliases']
+            return {
+                'hits': {
+                    'hits': [
+                        {'_source': {'aliases': [batch_ids[0]]}},
+                    ],
+                },
+            }
+
+        mod, _ = _load_dsl_query_builder()
+
+        # Patch _ADVISORIES_BATCH_SIZE to 2 so we get multiple batches
+        mod._ADVISORIES_BATCH_SIZE = 2
+        # Patch _execute_query directly since opensearch_request is bound at import
+        original_execute = mod._execute_query
+        mod._execute_query = mock_execute_query
+
+        try:
+            result, is_partial = mod.query_advisories(
+                cve_ids=['CVE-2024-0001', 'CVE-2024-0002', 'CVE-2024-1001', 'CVE-2024-1002'],
+                age_days=30,
+            )
+
+            # One batch failed, one succeeded — result should have exactly 1 match
+            assert len(result) == 1
+            # is_partial because first batch failed
+            assert is_partial is True
+        finally:
+            mod._execute_query = original_execute
+
+    def test_all_batches_succeed_is_partial_false(self):
+        """When all batches succeed, is_partial=False."""
+        def mock_execute_query(index, query_body):
+            """Return a hit matching the first ID in each batch."""
+            import json as _json
+            body = _json.loads(query_body)
+            batch_ids = body['query']['bool']['filter'][0]['terms']['aliases']
+            return {
+                'hits': {
+                    'hits': [
+                        {'_source': {'aliases': [batch_ids[0]]}},
+                    ],
+                },
+            }
+
+        mod, _ = _load_dsl_query_builder()
+
+        # Patch batch size to create two batches
+        mod._ADVISORIES_BATCH_SIZE = 2
+        # Patch _execute_query directly since opensearch_request is bound at import
+        original_execute = mod._execute_query
+        mod._execute_query = mock_execute_query
+
+        try:
+            result, is_partial = mod.query_advisories(
+                cve_ids=['CVE-2024-0001', 'CVE-2024-0002', 'CVE-2024-1001', 'CVE-2024-1002'],
+                age_days=30,
+            )
+
+            # Both batches succeeded — should have 2 matches (one per batch)
+            assert len(result) == 2
+            assert is_partial is False
+        finally:
+            mod._execute_query = original_execute
+
+
+class TestQueryAdvisoriesQueryConstruction:
+    """Test that the DSL query body is constructed correctly."""
+
+    def test_age_filter_produces_range_clause(self):
+        """When age_days is provided, a range filter on timestamp.publish is added."""
+        mock_response = {'hits': {'hits': []}}
+        mod, mock_aws = _load_dsl_query_builder(mock_opensearch_request=mock_response)
+
+        mod.query_advisories(cve_ids=['CVE-2024-0001'], age_days=30)
+
+        call_args = mock_aws.opensearch_request.call_args
+        body_str = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get('body')
+        body = json.loads(body_str)
+
+        filter_clauses = body['query']['bool']['filter']
+        # Should have terms (aliases) + range (timestamp.publish)
+        assert len(filter_clauses) == 2
+        assert filter_clauses[0] == {'terms': {'aliases': ['CVE-2024-0001']}}
+        assert 'range' in filter_clauses[1]
+        assert 'timestamp.publish' in filter_clauses[1]['range']
+        assert 'lte' in filter_clauses[1]['range']['timestamp.publish']
+
+    def test_severity_filter_produces_terms_clause(self):
+        """When severity is provided, a terms filter on severity is added."""
+        mock_response = {'hits': {'hits': []}}
+        mod, mock_aws = _load_dsl_query_builder(mock_opensearch_request=mock_response)
+
+        mod.query_advisories(
+            cve_ids=['CVE-2024-0001'],
+            severity={'HIGH', 'CRITICAL'},
+        )
+
+        call_args = mock_aws.opensearch_request.call_args
+        body_str = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get('body')
+        body = json.loads(body_str)
+
+        filter_clauses = body['query']['bool']['filter']
+        # Should have terms (aliases) + terms (severity)
+        assert len(filter_clauses) == 2
+        severity_clause = filter_clauses[1]
+        assert 'terms' in severity_clause
+        assert 'severity' in severity_clause['terms']
+        assert set(severity_clause['terms']['severity']) == {'HIGH', 'CRITICAL'}
+
+    def test_both_age_and_severity_produces_three_clauses(self):
+        """When both age_days and severity are provided, three filter clauses are produced."""
+        mock_response = {'hits': {'hits': []}}
+        mod, mock_aws = _load_dsl_query_builder(mock_opensearch_request=mock_response)
+
+        mod.query_advisories(
+            cve_ids=['CVE-2024-0001'],
+            age_days=60,
+            severity={'HIGH'},
+        )
+
+        call_args = mock_aws.opensearch_request.call_args
+        body_str = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get('body')
+        body = json.loads(body_str)
+
+        filter_clauses = body['query']['bool']['filter']
+        assert len(filter_clauses) == 3
+        # aliases terms, range, severity terms
+        assert filter_clauses[0] == {'terms': {'aliases': ['CVE-2024-0001']}}
+        assert 'range' in filter_clauses[1]
+        assert 'terms' in filter_clauses[2]
+        assert 'severity' in filter_clauses[2]['terms']
+
+    def test_query_targets_advisories_index(self):
+        """The query should target the 'advisories' index."""
+        mock_response = {'hits': {'hits': []}}
+        mod, mock_aws = _load_dsl_query_builder(mock_opensearch_request=mock_response)
+
+        mod.query_advisories(cve_ids=['CVE-2024-0001'], age_days=30)
+
+        call_args = mock_aws.opensearch_request.call_args
+        path = call_args[0][1]
+        assert path == '/advisories/_search'
+
+    def test_query_source_limited_to_aliases(self):
+        """The query should request only the aliases field in _source."""
+        mock_response = {'hits': {'hits': []}}
+        mod, mock_aws = _load_dsl_query_builder(mock_opensearch_request=mock_response)
+
+        mod.query_advisories(cve_ids=['CVE-2024-0001'], age_days=30)
+
+        call_args = mock_aws.opensearch_request.call_args
+        body_str = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get('body')
+        body = json.loads(body_str)
+
+        assert body['_source'] == ['aliases']
+
+    def test_query_size_equals_batch_length(self):
+        """The query size should equal the number of IDs in the batch."""
+        mock_response = {'hits': {'hits': []}}
+        mod, mock_aws = _load_dsl_query_builder(mock_opensearch_request=mock_response)
+
+        mod.query_advisories(
+            cve_ids=['CVE-2024-0001', 'CVE-2024-0002', 'CVE-2024-0003'],
+            age_days=30,
+        )
+
+        call_args = mock_aws.opensearch_request.call_args
+        body_str = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get('body')
+        body = json.loads(body_str)
+
+        assert body['size'] == 3
+
+    def test_severity_only_without_age_days_queries_successfully(self):
+        """Severity alone (without age_days) still triggers a query."""
+        mock_response = {
+            'hits': {
+                'hits': [
+                    {'_source': {'aliases': ['CVE-2024-0001']}},
+                ],
+            },
+        }
+        mod, mock_aws = _load_dsl_query_builder(mock_opensearch_request=mock_response)
+
+        result, is_partial = mod.query_advisories(
+            cve_ids=['CVE-2024-0001'],
+            severity={'CRITICAL'},
+        )
+
+        assert result == {'CVE-2024-0001'}
+        assert is_partial is False
+        # Verify no range clause was added
+        call_args = mock_aws.opensearch_request.call_args
+        body_str = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get('body')
+        body = json.loads(body_str)
+        filter_clauses = body['query']['bool']['filter']
+        assert len(filter_clauses) == 2  # aliases + severity only
+        assert not any('range' in clause for clause in filter_clauses)

--- a/tests/agents/security_advisories/test_map_age_and_neglected_url_call.py
+++ b/tests/agents/security_advisories/test_map_age_and_neglected_url_call.py
@@ -28,6 +28,7 @@ def _make_mock_dsl_query_builder():
     mock_mod = MagicMock()
     mock_mod.query_vulnerabilities = MagicMock(return_value={'hits': {'hits': []}})
     mock_mod.resolve_version_tag = MagicMock(side_effect=lambda v: v)
+    mock_mod.query_advisories = MagicMock(return_value=set())
     mock_mod._DEFAULT_QUERY_SIZE = 1000
     return mock_mod
 

--- a/tests/agents/security_advisories/test_map_age_and_neglected_url_call.py
+++ b/tests/agents/security_advisories/test_map_age_and_neglected_url_call.py
@@ -28,7 +28,7 @@ def _make_mock_dsl_query_builder():
     mock_mod = MagicMock()
     mock_mod.query_vulnerabilities = MagicMock(return_value={'hits': {'hits': []}})
     mock_mod.resolve_version_tag = MagicMock(side_effect=lambda v: v)
-    mock_mod.query_advisories = MagicMock(return_value=set())
+    mock_mod.query_advisories = MagicMock(return_value=(set(), False))
     mock_mod._DEFAULT_QUERY_SIZE = 1000
     return mock_mod
 

--- a/tests/agents/security_advisories/test_response_filter.py
+++ b/tests/agents/security_advisories/test_response_filter.py
@@ -75,65 +75,56 @@ class TestFilterVulnerabilities(unittest.TestCase):
 
         self.assertEqual(len(result), 5)
 
-    def test_filter_high_severity(self):
-        """'Show me high severity CVEs' — severity={"HIGH"}."""
-        result = filter_vulnerabilities(MOCK_VULNERABILITIES, severity={"HIGH"})
+    def test_allowlist_keeps_only_listed_cves(self):
+        """Only CVEs in the allowlist are returned (excluded still filtered)."""
+        allowed = {"CVE-2024-001", "CVE-2024-002"}
+        result = filter_vulnerabilities(MOCK_VULNERABILITIES, allowed_cve_ids=allowed)
+
+        self.assertEqual(len(result), 2)
+        ids = {v["id"] for v in result}
+        self.assertEqual(ids, {"CVE-2024-001", "CVE-2024-002"})
+
+    def test_allowlist_with_excluded_cve(self):
+        """Excluded CVEs are still filtered even if they're in the allowlist."""
+        allowed = {"CVE-2024-002", "CVE-2024-003"}  # CVE-003 is excluded
+        result = filter_vulnerabilities(MOCK_VULNERABILITIES, allowed_cve_ids=allowed)
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["id"], "CVE-2024-002")
 
-    def test_filter_high_severity_include_excluded(self):
-        """'Show me all high severity CVEs including excluded'."""
+    def test_allowlist_include_excluded(self):
+        """With include_excluded=True, excluded CVEs in the allowlist are kept."""
+        allowed = {"CVE-2024-002", "CVE-2024-003"}
         result = filter_vulnerabilities(
-            MOCK_VULNERABILITIES, severity={"HIGH"}, include_excluded=True
+            MOCK_VULNERABILITIES, allowed_cve_ids=allowed, include_excluded=True,
         )
 
         self.assertEqual(len(result), 2)
         ids = {v["id"] for v in result}
-        self.assertIn("CVE-2024-002", ids)
-        self.assertIn("CVE-2024-003", ids)
+        self.assertEqual(ids, {"CVE-2024-002", "CVE-2024-003"})
 
-    def test_filter_critical_severity(self):
-        """'Show me critical CVEs'."""
-        result = filter_vulnerabilities(MOCK_VULNERABILITIES, severity={"CRITICAL"})
+    def test_allowlist_no_match(self):
+        """Allowlist with no matching CVEs returns empty."""
+        allowed = {"CVE-9999-999"}
+        result = filter_vulnerabilities(MOCK_VULNERABILITIES, allowed_cve_ids=allowed)
+        self.assertEqual(result, [])
 
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["id"], "CVE-2024-001")
+    def test_allowlist_none_means_no_filtering(self):
+        """When allowed_cve_ids is None, all non-excluded CVEs pass through."""
+        result = filter_vulnerabilities(MOCK_VULNERABILITIES, allowed_cve_ids=None)
 
-    def test_filter_multiple_severities(self):
-        """'Show me high and critical CVEs'."""
-        result = filter_vulnerabilities(
-            MOCK_VULNERABILITIES, severity={"HIGH", "CRITICAL"}
-        )
-
-        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result), 3)
         ids = {v["id"] for v in result}
-        self.assertIn("CVE-2024-001", ids)
-        self.assertIn("CVE-2024-002", ids)
-
-    def test_filter_low_severity(self):
-        """'Show me low severity CVEs' — the only LOW one is excluded."""
-        result = filter_vulnerabilities(MOCK_VULNERABILITIES, severity={"LOW"})
-
-        self.assertEqual(len(result), 0)
-
-    def test_filter_low_severity_include_excluded(self):
-        """'Show me low severity CVEs including excluded'."""
-        result = filter_vulnerabilities(
-            MOCK_VULNERABILITIES, severity={"LOW"}, include_excluded=True
-        )
-
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["id"], "CVE-2024-005")
+        self.assertEqual(ids, {"CVE-2024-001", "CVE-2024-002", "CVE-2024-004"})
 
     def test_empty_vulnerabilities(self):
         """No vulnerabilities at all."""
         result = filter_vulnerabilities([])
         self.assertEqual(result, [])
 
-    def test_severity_filter_no_match(self):
-        """Filter for a severity that doesn't exist."""
-        result = filter_vulnerabilities(MOCK_VULNERABILITIES, severity={"UNKNOWN"})
+    def test_empty_allowlist_returns_empty(self):
+        """An empty allowlist (not None) means nothing passes."""
+        result = filter_vulnerabilities(MOCK_VULNERABILITIES, allowed_cve_ids=set())
         self.assertEqual(result, [])
 
 
@@ -157,26 +148,28 @@ class TestBuildSummary(unittest.TestCase):
         self.assertEqual(summary, {})
 
     def test_summary_single_severity(self):
-        filtered = filter_vulnerabilities(MOCK_VULNERABILITIES, severity={"CRITICAL"})
+        # Use allowlist to keep only the CRITICAL CVE
+        filtered = filter_vulnerabilities(
+            MOCK_VULNERABILITIES, allowed_cve_ids={"CVE-2024-001"},
+        )
         summary = build_summary(filtered)
 
         self.assertEqual(summary, {"CRITICAL": 1})
 
 
-class TestProperty2SeverityFilterCorrectness(unittest.TestCase):
+class TestProperty2AllowlistFilterCorrectness(unittest.TestCase):
     """**Validates: Requirements 3.2**
 
-    Property 2: Severity filter returns only matching severities and drops
-    none that match.
+    Property 2: Allowlist filter returns only CVEs in the allowed set and
+    drops none that match.
 
-    For any list of vulnerability dicts and any non-empty subset of severity
-    levels, filter_vulnerabilities with that severity set SHALL return only
-    vulnerabilities whose severity is in the filter set, and SHALL return all
-    vulnerabilities from the input whose severity is in the filter set (no
-    false drops).
+    For any list of vulnerability dicts and any non-empty allowlist,
+    filter_vulnerabilities with that allowlist SHALL return only
+    vulnerabilities whose ID is in the allowed set, and SHALL return all
+    non-excluded vulnerabilities from the input whose ID is in the allowed set.
     """
 
-    def _make_vuln(self, vuln_id, severity, excluded=None):
+    def _make_vuln(self, vuln_id, severity="HIGH", excluded=None):
         """Helper to create a vulnerability dict."""
         vuln = {
             "id": vuln_id,
@@ -187,8 +180,8 @@ class TestProperty2SeverityFilterCorrectness(unittest.TestCase):
             vuln["excluded"] = excluded
         return vuln
 
-    def test_single_severity_returns_only_matching(self):
-        """Only vulns with the requested severity are returned."""
+    def test_allowlist_returns_only_matching(self):
+        """Only vulns with IDs in the allowlist are returned."""
         vulns = [
             self._make_vuln("CVE-1", "CRITICAL"),
             self._make_vuln("CVE-2", "HIGH"),
@@ -196,14 +189,14 @@ class TestProperty2SeverityFilterCorrectness(unittest.TestCase):
             self._make_vuln("CVE-4", "HIGH"),
             self._make_vuln("CVE-5", "LOW"),
         ]
-        result = filter_vulnerabilities(vulns, severity={"HIGH"})
+        allowed = {"CVE-2", "CVE-4"}
+        result = filter_vulnerabilities(vulns, allowed_cve_ids=allowed)
 
-        # All returned vulns must have severity HIGH
         for v in result:
-            self.assertEqual(v["severity"], "HIGH")
+            self.assertIn(v["id"], allowed)
 
-    def test_single_severity_drops_none_that_match(self):
-        """All non-excluded vulns matching the severity are returned."""
+    def test_allowlist_drops_none_that_match(self):
+        """All non-excluded vulns in the allowlist are returned."""
         vulns = [
             self._make_vuln("CVE-1", "CRITICAL"),
             self._make_vuln("CVE-2", "HIGH"),
@@ -211,76 +204,64 @@ class TestProperty2SeverityFilterCorrectness(unittest.TestCase):
             self._make_vuln("CVE-4", "HIGH"),
             self._make_vuln("CVE-5", "LOW"),
         ]
-        result = filter_vulnerabilities(vulns, severity={"HIGH"})
+        allowed = {"CVE-2", "CVE-4"}
+        result = filter_vulnerabilities(vulns, allowed_cve_ids=allowed)
 
         result_ids = {v["id"] for v in result}
         self.assertEqual(result_ids, {"CVE-2", "CVE-4"})
 
-    def test_multiple_severities_returns_only_matching(self):
-        """Only vulns with one of the requested severities are returned."""
+    def test_allowlist_with_multiple_ids(self):
+        """Multiple IDs in allowlist all pass through."""
         vulns = [
             self._make_vuln("CVE-1", "CRITICAL"),
             self._make_vuln("CVE-2", "HIGH"),
             self._make_vuln("CVE-3", "MEDIUM"),
             self._make_vuln("CVE-4", "LOW"),
         ]
+        allowed = {"CVE-1", "CVE-4"}
         result = filter_vulnerabilities(
-            vulns, severity={"CRITICAL", "LOW"}, include_excluded=True
-        )
-
-        severities = {v["severity"] for v in result}
-        self.assertTrue(severities.issubset({"CRITICAL", "LOW"}))
-
-    def test_multiple_severities_drops_none_that_match(self):
-        """All non-excluded vulns matching any of the severities are returned."""
-        vulns = [
-            self._make_vuln("CVE-1", "CRITICAL"),
-            self._make_vuln("CVE-2", "HIGH"),
-            self._make_vuln("CVE-3", "MEDIUM"),
-            self._make_vuln("CVE-4", "LOW"),
-        ]
-        result = filter_vulnerabilities(
-            vulns, severity={"CRITICAL", "LOW"}, include_excluded=True
+            vulns, allowed_cve_ids=allowed, include_excluded=True,
         )
 
         result_ids = {v["id"] for v in result}
         self.assertEqual(result_ids, {"CVE-1", "CVE-4"})
 
-    def test_severity_filter_with_excluded_vulns(self):
-        """Excluded vulns matching severity are dropped when include_excluded=False."""
+    def test_allowlist_respects_exclusion(self):
+        """Excluded vulns in the allowlist are dropped when include_excluded=False."""
         vulns = [
             self._make_vuln("CVE-1", "HIGH"),
             self._make_vuln("CVE-2", "HIGH", excluded="AT_PROJECT"),
             self._make_vuln("CVE-3", "HIGH"),
         ]
-        result = filter_vulnerabilities(vulns, severity={"HIGH"})
+        allowed = {"CVE-1", "CVE-2", "CVE-3"}
+        result = filter_vulnerabilities(vulns, allowed_cve_ids=allowed)
 
         # CVE-2 is excluded, so only CVE-1 and CVE-3 should be returned
         result_ids = {v["id"] for v in result}
         self.assertEqual(result_ids, {"CVE-1", "CVE-3"})
 
-    def test_severity_filter_with_all_severities(self):
-        """Filtering with all four severity levels returns all non-excluded vulns."""
+    def test_allowlist_all_ids_returns_all_non_excluded(self):
+        """Allowlist containing all IDs returns all non-excluded vulns."""
         vulns = [
             self._make_vuln("CVE-1", "CRITICAL"),
             self._make_vuln("CVE-2", "HIGH"),
             self._make_vuln("CVE-3", "MEDIUM"),
             self._make_vuln("CVE-4", "LOW"),
         ]
-        all_severities = {"CRITICAL", "HIGH", "MEDIUM", "LOW"}
-        result = filter_vulnerabilities(vulns, severity=all_severities)
+        all_ids = {"CVE-1", "CVE-2", "CVE-3", "CVE-4"}
+        result = filter_vulnerabilities(vulns, allowed_cve_ids=all_ids)
 
         self.assertEqual(len(result), 4)
 
-    def test_severity_none_returns_all_non_excluded(self):
-        """When severity is None, all non-excluded vulns are returned regardless of severity."""
+    def test_allowlist_none_returns_all_non_excluded(self):
+        """When allowed_cve_ids is None, all non-excluded vulns are returned."""
         vulns = [
             self._make_vuln("CVE-1", "CRITICAL"),
             self._make_vuln("CVE-2", "HIGH"),
             self._make_vuln("CVE-3", "MEDIUM"),
             self._make_vuln("CVE-4", "LOW"),
         ]
-        result = filter_vulnerabilities(vulns, severity=None)
+        result = filter_vulnerabilities(vulns, allowed_cve_ids=None)
 
         self.assertEqual(len(result), 4)
 
@@ -354,16 +335,17 @@ class TestProperty3ExclusionFilterCorrectness(unittest.TestCase):
         expected_ids = {v["id"] for v in vulns}
         self.assertEqual(result_ids, expected_ids)
 
-    def test_include_excluded_true_with_severity_filter(self):
-        """With include_excluded=True and severity filter, excluded vulns matching severity are kept."""
+    def test_include_excluded_true_with_allowlist(self):
+        """With include_excluded=True and allowlist, excluded vulns in allowlist are kept."""
         vulns = [
             self._make_vuln("CVE-1", severity="HIGH"),
             self._make_vuln("CVE-2", severity="HIGH", excluded="AT_PROJECT"),
             self._make_vuln("CVE-3", severity="LOW"),
             self._make_vuln("CVE-4", severity="LOW", excluded="AT_RULE"),
         ]
+        allowed = {"CVE-1", "CVE-2"}
         result = filter_vulnerabilities(
-            vulns, severity={"HIGH"}, include_excluded=True
+            vulns, allowed_cve_ids=allowed, include_excluded=True,
         )
 
         result_ids = {v["id"] for v in result}
@@ -500,7 +482,8 @@ class TestProperty4SeveritySummaryAccuracy(unittest.TestCase):
             self._make_vuln("CVE-3", "MEDIUM"),
             self._make_vuln("CVE-4", "LOW"),
         ]
-        filtered = filter_vulnerabilities(vulns, severity={"CRITICAL", "HIGH"})
+        allowed = {"CVE-1", "CVE-2"}
+        filtered = filter_vulnerabilities(vulns, allowed_cve_ids=allowed)
         summary = build_summary(filtered)
 
         self.assertEqual(summary, {"CRITICAL": 1, "HIGH": 1})

--- a/tests/agents/security_advisories/test_severity_and_age_filtering.py
+++ b/tests/agents/security_advisories/test_severity_and_age_filtering.py
@@ -34,7 +34,7 @@ def _make_mock_dsl_query_builder():
     mock_mod = MagicMock()
     mock_mod.query_vulnerabilities = MagicMock(return_value={'hits': {'hits': []}})
     mock_mod.resolve_version_tag = MagicMock(side_effect=lambda v: v)
-    mock_mod.query_advisories = MagicMock(return_value=set())
+    mock_mod.query_advisories = MagicMock(return_value=(set(), False))
     mock_mod._DEFAULT_QUERY_SIZE = 1000
     return mock_mod
 
@@ -203,7 +203,7 @@ class TestSeverityFilteringIntegration:
             _make_vuln('CVE-003', 'MEDIUM'),
         ])
         mock_dsl.query_vulnerabilities.return_value = {'hits': {'total': {'value': 1}, 'hits': [hit]}}
-        mock_dsl.query_advisories.return_value = {'CVE-001'}
+        mock_dsl.query_advisories.return_value = ({'CVE-001'}, False)
         mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
@@ -225,7 +225,7 @@ class TestSeverityFilteringIntegration:
             _make_vuln('CVE-004', 'LOW'),
         ])
         mock_dsl.query_vulnerabilities.return_value = {'hits': {'total': {'value': 1}, 'hits': [hit]}}
-        mock_dsl.query_advisories.return_value = {'CVE-001', 'CVE-002'}
+        mock_dsl.query_advisories.return_value = ({'CVE-001', 'CVE-002'}, False)
         mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
@@ -266,7 +266,7 @@ class TestSeverityFilteringIntegration:
             _make_vuln('CVE-004', 'MEDIUM'),
         ])
         mock_dsl.query_vulnerabilities.return_value = {'hits': {'total': {'value': 1}, 'hits': [hit]}}
-        mock_dsl.query_advisories.return_value = {'CVE-001', 'CVE-002'}
+        mock_dsl.query_advisories.return_value = ({'CVE-001', 'CVE-002'}, False)
         mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
@@ -313,7 +313,7 @@ class TestAgeThresholdIntegration:
         ], scan_timestamp=old_ts)
         mock_dsl.query_vulnerabilities.return_value = {'hits': {'total': {'value': 1}, 'hits': [hit]}}
         # Only CVE-001 is old enough
-        mock_dsl.query_advisories.return_value = {'CVE-001'}
+        mock_dsl.query_advisories.return_value = ({'CVE-001'}, False)
         mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
@@ -331,7 +331,7 @@ class TestAgeThresholdIntegration:
             _make_vuln('CVE-001', 'HIGH'),
         ])
         mock_dsl.query_vulnerabilities.return_value = {'hits': {'total': {'value': 1}, 'hits': [hit]}}
-        mock_dsl.query_advisories.return_value = set()
+        mock_dsl.query_advisories.return_value = (set(), False)
         mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
@@ -348,7 +348,7 @@ class TestAgeThresholdIntegration:
             _make_vuln('CVE-001', 'HIGH'),
         ])
         mock_dsl.query_vulnerabilities.return_value = {'hits': {'total': {'value': 1}, 'hits': [hit]}}
-        mock_dsl.query_advisories.return_value = {'CVE-001'}
+        mock_dsl.query_advisories.return_value = ({'CVE-001'}, False)
         mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
@@ -403,7 +403,7 @@ class TestCombinedSeverityAndAge:
             'hits': {'total': {'value': 2}, 'hits': [hit_recent, hit_old]},
         }
         # Both CRITICAL CVEs are old enough
-        mock_dsl.query_advisories.return_value = {'CVE-001', 'CVE-004'}
+        mock_dsl.query_advisories.return_value = ({'CVE-001', 'CVE-004'}, False)
         mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
@@ -429,7 +429,7 @@ class TestCombinedSeverityAndAge:
             'hits': {'total': {'value': 1}, 'hits': [hit]},
         }
         # Only CVE-001 is old enough, CVE-002 is not
-        mock_dsl.query_advisories.return_value = {'CVE-001'}
+        mock_dsl.query_advisories.return_value = ({'CVE-001'}, False)
         mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(

--- a/tests/agents/security_advisories/test_severity_and_age_filtering.py
+++ b/tests/agents/security_advisories/test_severity_and_age_filtering.py
@@ -7,8 +7,9 @@ These tests cover _parse_severity, _parse_age_days helper functions, and the
 end-to-end integration of severity and age_days parameters through
 handle_query_vulnerabilities.
 
-Note: age_days no longer filters scan hits (since the DSL query targets
-a single latest-scan index). It is only used to build the neglected page URL.
+Note: age_days now filters CVEs via the advisories index. When age_days is
+provided, only CVEs whose advisory was published at least that many days ago
+are retained in results.
 
 **Validates Acceptance Criteria 3: Query results are returned and processed
 accurately for a given release version, severity, repository and age threshold.**
@@ -33,6 +34,7 @@ def _make_mock_dsl_query_builder():
     mock_mod = MagicMock()
     mock_mod.query_vulnerabilities = MagicMock(return_value={'hits': {'hits': []}})
     mock_mod.resolve_version_tag = MagicMock(side_effect=lambda v: v)
+    mock_mod.query_advisories = MagicMock(return_value=set())
     mock_mod._DEFAULT_QUERY_SIZE = 1000
     return mock_mod
 
@@ -201,6 +203,7 @@ class TestSeverityFilteringIntegration:
             _make_vuln('CVE-003', 'MEDIUM'),
         ])
         mock_dsl.query_vulnerabilities.return_value = {'hits': {'total': {'value': 1}, 'hits': [hit]}}
+        mock_dsl.query_advisories.return_value = {'CVE-001'}
         mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
@@ -222,6 +225,7 @@ class TestSeverityFilteringIntegration:
             _make_vuln('CVE-004', 'LOW'),
         ])
         mock_dsl.query_vulnerabilities.return_value = {'hits': {'total': {'value': 1}, 'hits': [hit]}}
+        mock_dsl.query_advisories.return_value = {'CVE-001', 'CVE-002'}
         mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
@@ -262,6 +266,7 @@ class TestSeverityFilteringIntegration:
             _make_vuln('CVE-004', 'MEDIUM'),
         ])
         mock_dsl.query_vulnerabilities.return_value = {'hits': {'total': {'value': 1}, 'hits': [hit]}}
+        mock_dsl.query_advisories.return_value = {'CVE-001', 'CVE-002'}
         mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
@@ -291,21 +296,24 @@ class TestSeverityFilteringIntegration:
 
 
 # ---------------------------------------------------------------------------
-# Age threshold — age_days is used only for neglected page URL, not filtering
+# Age threshold — age_days filters CVEs via advisories index
 # ---------------------------------------------------------------------------
 
 
 class TestAgeThresholdIntegration:
-    """Verify age_days is parsed and passed to neglected URL but does not filter hits."""
+    """Verify age_days filters CVEs via the advisories index and affects neglected URL."""
 
-    def test_age_days_does_not_filter_old_scans(self):
-        """Old scans are NOT filtered out — age_days only affects neglected URL."""
+    def test_age_days_filters_cves_via_advisories(self):
+        """Only CVEs returned by query_advisories are retained."""
         mock_dsl = _make_mock_dsl_query_builder()
         old_ts = '2020-01-01T00:00:00Z'
         hit = _make_hit('OpenSearch', '2.19.6', [
             _make_vuln('CVE-001', 'HIGH'),
+            _make_vuln('CVE-002', 'MEDIUM'),
         ], scan_timestamp=old_ts)
         mock_dsl.query_vulnerabilities.return_value = {'hits': {'total': {'value': 1}, 'hits': [hit]}}
+        # Only CVE-001 is old enough
+        mock_dsl.query_advisories.return_value = {'CVE-001'}
         mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
@@ -313,6 +321,25 @@ class TestAgeThresholdIntegration:
         )
 
         assert result['result_count'] == 1
+        assert result['results'][0]['filtered_count'] == 1
+        assert result['results'][0]['filtered_vulnerabilities'][0]['id'] == 'CVE-001'
+
+    def test_age_days_no_old_cves_returns_empty_filtered(self):
+        """When no CVEs are old enough, filtered_count is 0."""
+        mock_dsl = _make_mock_dsl_query_builder()
+        hit = _make_hit('OpenSearch', '2.19.6', [
+            _make_vuln('CVE-001', 'HIGH'),
+        ])
+        mock_dsl.query_vulnerabilities.return_value = {'hits': {'total': {'value': 1}, 'hits': [hit]}}
+        mock_dsl.query_advisories.return_value = set()
+        mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
+
+        result = mod.handle_query_vulnerabilities(
+            {'query': 'Show CVEs', 'version': '2.19', 'age_days': '30', '_access_tier': 'privileged'}, 'test-age-004',
+        )
+
+        assert result['result_count'] == 1
+        assert result['results'][0]['filtered_count'] == 0
 
     def test_age_days_reflected_in_neglected_url(self):
         """age_days should map to the age param in the neglected URL."""
@@ -321,6 +348,7 @@ class TestAgeThresholdIntegration:
             _make_vuln('CVE-001', 'HIGH'),
         ])
         mock_dsl.query_vulnerabilities.return_value = {'hits': {'total': {'value': 1}, 'hits': [hit]}}
+        mock_dsl.query_advisories.return_value = {'CVE-001'}
         mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
@@ -330,7 +358,7 @@ class TestAgeThresholdIntegration:
         assert 'age=30d' in result['neglected_page_url']
 
     def test_invalid_age_days_still_returns_results(self):
-        """Invalid age_days should not affect results."""
+        """Invalid age_days should not trigger age filtering."""
         mock_dsl = _make_mock_dsl_query_builder()
         old_ts = '2020-01-01T00:00:00Z'
         hit = _make_hit('OpenSearch', '2.19.6', [
@@ -343,7 +371,9 @@ class TestAgeThresholdIntegration:
             {'query': 'Show CVEs', 'version': '2.19', 'age_days': 'abc', '_access_tier': 'privileged'}, 'test-age-003',
         )
 
+        # Invalid age_days is parsed to None, so no age filtering happens
         assert result['result_count'] == 1
+        assert result['results'][0]['filtered_count'] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -352,10 +382,10 @@ class TestAgeThresholdIntegration:
 
 
 class TestCombinedSeverityAndAge:
-    """Verify severity filters vulns while age_days only affects neglected URL."""
+    """Verify severity filters vulns and age_days filters via advisories index."""
 
-    def test_severity_filters_vulns_age_does_not_filter_hits(self):
-        """Severity filters CVEs within hits; age_days does not remove hits."""
+    def test_severity_and_age_combined_filtering(self):
+        """Severity filters CVEs within hits; age_days filters via advisories."""
         mock_dsl = _make_mock_dsl_query_builder()
         recent_ts = datetime.now(timezone.utc).isoformat()
         old_ts = '2020-01-01T00:00:00Z'
@@ -372,6 +402,8 @@ class TestCombinedSeverityAndAge:
         mock_dsl.query_vulnerabilities.return_value = {
             'hits': {'total': {'value': 2}, 'hits': [hit_recent, hit_old]},
         }
+        # Both CRITICAL CVEs are old enough
+        mock_dsl.query_advisories.return_value = {'CVE-001', 'CVE-004'}
         mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
 
         result = mod.handle_query_vulnerabilities(
@@ -379,12 +411,34 @@ class TestCombinedSeverityAndAge:
             'test-combo-001',
         )
 
-        # Both hits are returned (age doesn't filter), severity filters vulns
+        # Both hits are returned; severity + age filtering applied
         assert result['result_count'] == 2
         assert result['results'][0]['filtered_count'] == 1
         assert result['results'][0]['filtered_vulnerabilities'][0]['id'] == 'CVE-001'
         assert result['results'][1]['filtered_count'] == 1
         assert result['results'][1]['filtered_vulnerabilities'][0]['id'] == 'CVE-004'
+
+    def test_age_filter_removes_young_cves_even_with_matching_severity(self):
+        """CVEs matching severity but not age are excluded."""
+        mock_dsl = _make_mock_dsl_query_builder()
+        hit = _make_hit('OpenSearch', '2.19.6', [
+            _make_vuln('CVE-001', 'CRITICAL'),
+            _make_vuln('CVE-002', 'CRITICAL'),
+        ])
+        mock_dsl.query_vulnerabilities.return_value = {
+            'hits': {'total': {'value': 1}, 'hits': [hit]},
+        }
+        # Only CVE-001 is old enough, CVE-002 is not
+        mock_dsl.query_advisories.return_value = {'CVE-001'}
+        mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
+
+        result = mod.handle_query_vulnerabilities(
+            {'query': 'Show CVEs', 'version': '2.19', 'severity': 'CRITICAL', 'age_days': '60', '_access_tier': 'privileged'},
+            'test-combo-002',
+        )
+
+        assert result['results'][0]['filtered_count'] == 1
+        assert result['results'][0]['filtered_vulnerabilities'][0]['id'] == 'CVE-001'
 
 
 # ---------------------------------------------------------------------------
@@ -459,7 +513,7 @@ class TestInstructionDocumentation:
 
     def test_instruction_has_age_days_example(self, agent):
         instruction = agent.get_agent_instruction()
-        assert 'age_days="30"' in instruction or 'age_days="7"' in instruction
+        assert 'age_days=30' in instruction or 'age_days=60' in instruction
 
     def test_instruction_documents_valid_severity_values(self, agent):
         instruction = agent.get_agent_instruction()

--- a/tests/agents/security_advisories/test_vulnerabilities_handler.py
+++ b/tests/agents/security_advisories/test_vulnerabilities_handler.py
@@ -598,3 +598,32 @@ class TestPrivilegedResponseEnrichment:
 
         # Empty results return a message-style response
         assert result['status'] == 'success'
+
+    def test_severity_filter_with_empty_vulnerabilities_returns_zero_filtered(self):
+        """When severity is specified but scan hits have empty vulnerabilities arrays,
+        filtered_count should be 0 (not unfiltered passthrough)."""
+        hit_no_vulns = {
+            '_index': 'scans',
+            '_source': {
+                'project': {'name': 'OpenSearch', 'tag': '2.19.6'},
+                'vulnerabilities': [],
+                'count': {'severe': 0, 'minor': 0},
+                'timestamp': {'scan': '2024-01-15T10:30:00Z'},
+            },
+        }
+        mock_dsl = _make_mock_dsl_query_builder()
+        mock_dsl.query_vulnerabilities.return_value = {
+            'hits': {'total': {'value': 1}, 'hits': [hit_no_vulns]},
+        }
+        mod, _ = _load_vulnerabilities_handler(mock_dsl=mock_dsl)
+
+        result = mod.handle_query_vulnerabilities(
+            {'query': 'Show critical CVEs', 'severity': 'CRITICAL'}, 'test-048',
+        )
+
+        assert result['status'] == 'success'
+        assert result['result_count'] == 1
+        # The key assertion: with severity filter active but no CVEs in the scan,
+        # filtered_count must be 0 (not passthrough of all vulnerabilities).
+        assert result['results'][0]['filtered_count'] == 0
+        assert result['results'][0]['filtered_vulnerabilities'] == []

--- a/tests/agents/security_advisories/test_vulnerabilities_handler.py
+++ b/tests/agents/security_advisories/test_vulnerabilities_handler.py
@@ -26,7 +26,7 @@ def _make_mock_dsl_query_builder():
     mock_mod = MagicMock()
     mock_mod.query_vulnerabilities = MagicMock(return_value={'hits': {'total': {'value': 0}, 'hits': []}})
     mock_mod.resolve_version_tag = MagicMock(side_effect=lambda v: v)
-    mock_mod.query_advisories = MagicMock(return_value=set())
+    mock_mod.query_advisories = MagicMock(return_value=(set(), False))
     mock_mod._DEFAULT_QUERY_SIZE = 1000
     return mock_mod
 

--- a/tests/agents/security_advisories/test_vulnerabilities_handler.py
+++ b/tests/agents/security_advisories/test_vulnerabilities_handler.py
@@ -26,6 +26,7 @@ def _make_mock_dsl_query_builder():
     mock_mod = MagicMock()
     mock_mod.query_vulnerabilities = MagicMock(return_value={'hits': {'total': {'value': 0}, 'hits': []}})
     mock_mod.resolve_version_tag = MagicMock(side_effect=lambda v: v)
+    mock_mod.query_advisories = MagicMock(return_value=set())
     mock_mod._DEFAULT_QUERY_SIZE = 1000
     return mock_mod
 


### PR DESCRIPTION
### Description
- Adds the ability to filter vulnerability results by CVE age (days since publication). Queries the advisories index to determine which CVEs meet the criteria, then uses that as an allowlist when processing scan results.
- Moves severity filtering to the advisories DSL query rather than application-side, so OpenSearch handles the filtering and we avoid pulling unnecessary documents.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
