### PR TITLE
Add SIM ticketing retrieval to advisories agent

### DIFF
--- a/agents/security_advisories/action_groups.py
+++ b/agents/security_advisories/action_groups.py
@@ -94,6 +94,42 @@ def _privileged_action_group(
                     ),
                     parameters={},
                 ),
+                bedrock.CfnAgent.FunctionProperty(
+                    name="query_tickets",
+                    description=(
+                        "Query SIM tickets by CVE ID, project name, or branch."
+                    ),
+                    parameters={
+                        "cve_id": bedrock.CfnAgent.ParameterDetailProperty(
+                            type="string",
+                            description=(
+                                "CVE identifier to filter tickets (e.g., 'CVE-2026-27903')."
+                            ),
+                            required=False,
+                        ),
+                        "project_name": bedrock.CfnAgent.ParameterDetailProperty(
+                            type="string",
+                            description=(
+                                "Project or component name to filter tickets."
+                            ),
+                            required=False,
+                        ),
+                        "branch": bedrock.CfnAgent.ParameterDetailProperty(
+                            type="string",
+                            description=(
+                                "Branch name to filter tickets (e.g., 'origin/main' or 'origin/3.7')."
+                            ),
+                            required=False,
+                        ),
+                    },
+                ),
+                bedrock.CfnAgent.FunctionProperty(
+                    name="list_ticket_projects",
+                    description=(
+                        "List projects that currently have assigned SIM tickets."
+                    ),
+                    parameters={},
+                ),
             ]
         ),
     )

--- a/agents/security_advisories/instructions.py
+++ b/agents/security_advisories/instructions.py
@@ -6,7 +6,7 @@
 AGENT_INSTRUCTION = """You are the Security Advisories Specialist for OSCAR.
 
 ## CORE PURPOSE
-You help users query and understand CVEs and security vulnerabilities affecting OpenSearch project components. Your data comes from the security advisories scanning system which cross-references project SBOMs (Software Bills of Materials) against known security advisories.
+You help users query and understand CVEs and security vulnerabilities affecting OpenSearch project components, and track SIM tickets associated with remediation efforts. Your data comes from the security advisories scanning system which cross-references project SBOMs (Software Bills of Materials) against known security advisories, and a tickets index that tracks assigned remediation work.
 
 ## HOW YOU WORK — DIRECT DSL QUERY
 When you call `query_vulnerabilities`, the system constructs an OpenSearch DSL query directly from the structured parameters you provide (version, project_name). There is no natural language translation step — parameters map deterministically to query clauses. Conversational continuity is handled by the Bedrock session.
@@ -59,6 +59,8 @@ If the user does NOT specify a version or tag (e.g., "CVEs for OpenSearch"), def
 |----------|---------|-------------|
 | `query_vulnerabilities` | Query CVEs using structured parameters (version, project_name) via direct DSL construction | Any vulnerability query |
 | `list_projects` | List available components and tags | When user needs to discover what's available, or to resolve a user-provided project name to its canonical form |
+| `query_tickets` | Query SIM tickets by CVE ID, project name, or branch | When user asks about remediation tickets, tracking tickets, or SIM tickets for a CVE or project |
+| `list_ticket_projects` | List projects that currently have assigned SIM tickets | When user wants to know which projects have open ticket work |
 
 ### query_vulnerabilities parameters
 | Parameter | Required | Description |
@@ -68,6 +70,16 @@ If the user does NOT specify a version or tag (e.g., "CVEs for OpenSearch"), def
 | `project_name` | No | Project name to scope the query (e.g., "OpenSearch Dashboards") |
 | `severity` | No | Comma-separated severity filter applied to results (e.g., "CRITICAL", "CRITICAL,HIGH"). Valid values: CRITICAL, HIGH, MEDIUM, LOW |
 | `age_days` | No | Integer minimum age in days — only return CVEs published at least this many days ago. Extract from phrases like "older than 60 days" → age_days=60, "2 weeks" → age_days=14. Default to 60 for release prep queries. |
+
+### query_tickets parameters
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `cve_id` | No | CVE identifier to filter tickets (e.g., "CVE-2026-27903") |
+| `project_name` | No | Project or component name to filter tickets |
+| `branch` | No | Branch name to filter tickets (e.g., "origin/main" or "origin/3.7") |
+
+### list_ticket_projects parameters
+No parameters. Returns the list of projects that currently have assigned tickets.
 
 ## HANDLING AMBIGUOUS VERSION QUERIES
 When the user's query contains vague version language ("most recent", "latest", "newest", "current") instead of a concrete tag or version number:
@@ -91,6 +103,14 @@ NOTE: In all examples below, the agent MUST call `list_projects()` first to reso
 - "Show me CVEs for origin/3.7" → query_vulnerabilities(query="Show me CVEs for origin/3.7", version="origin/3.7")
 - "What components are tracked?" → list_projects()
 
+### Ticket Query Examples
+NOTE: When the user provides a project name for ticket queries, ALWAYS call `list_ticket_projects()` first to resolve the exact canonical project name before passing it to `query_tickets`. If the user's project name does not clearly match any project in the list, present the available projects and ask for clarification.
+
+- "Show me tickets for CVE-2026-27903" → query_tickets(cve_id="CVE-2026-27903") — no project resolution needed for CVE-only queries
+- "What tickets does Dashboards have?" → FIRST list_ticket_projects() to resolve "Dashboards" to the canonical name, THEN query_tickets(project_name=<canonical name from list_ticket_projects>)
+- "Tickets blocking the 3.7 release" → query_tickets(branch="origin/3.7")
+- "Which projects have open tickets?" → list_ticket_projects()
+
 ## RESPONSE GUIDELINES
 - Always state which project and tag the results are for
 - Clearly separate open CVEs from excluded ones
@@ -107,13 +127,15 @@ NOTE: In all examples below, the agent MUST call `list_projects()` first to reso
 - Include component name and tag for each result set
 - When results are empty (result_count is 0 or all filtered_count values are 0), state concisely that no matching vulnerabilities were found for the specified query parameters. Do NOT offer suggestions, do NOT ask follow-up questions, do NOT speculate about other severity levels or versions. Just state the fact and include the neglected page link.
 - NEVER expose internal function names (like list_projects, query_vulnerabilities) to the user. Describe capabilities in plain language instead (e.g., "I can show you all tracked components and their available versions").
+- When displaying ticket results, present each ticket as a markdown link where the link text is the URL without the "https://" prefix for a clean look (e.g., "[t.corp.amazon.com/V123456](https://t.corp.amazon.com/V123456)"). Use the `ticket_url` field from each result.
 """
 
 COLLABORATOR_INSTRUCTION = (
     "This Security-Advisories-Specialist agent retrieves and analyzes CVEs and "
     "security vulnerabilities affecting OpenSearch project components. It can query "
     "vulnerability scan results using natural language, scoped by component and release "
-    "version. It can also list available projects and tags for discovery. "
+    "version. It can also list available projects and tags for discovery, and query "
+    "SIM tickets associated with CVEs, projects, or branches to track remediation progress. "
     "Collaborate with this Security-Advisories-Specialist for all security vulnerability "
-    "queries, CVE lookups, and vulnerability trend analysis."
+    "queries, CVE lookups, vulnerability trend analysis, and ticket tracking."
 )

--- a/agents/security_advisories/lambda/dsl_query_builder.py
+++ b/agents/security_advisories/lambda/dsl_query_builder.py
@@ -9,91 +9,24 @@ for vulnerability queries. It replaces the previous agentic search flow that
 relied on an ML-powered pipeline for NL→DSL translation.
 
 Functions:
-    resolve_version_tag: Map user-provided version to canonical tag format
+    resolve_version_tag: Map user-provided version to canonical tag format (re-exported from query_utils)
     query_vulnerabilities: Construct and execute a DSL query for vulnerability scans
     query_advisories: Query advisories index to filter CVEs by age and/or severity
 """
 
 import json
 import logging
-import re
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-import semver
 from aws_utils import get_latest_scans_index, opensearch_request
+from query_utils import connection_error, error_response, resolve_version_tag
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 # Default query size — matches the previous agentic search configuration
 _DEFAULT_QUERY_SIZE = 1000
-
-# Strict two-part numeric pattern (e.g., "3.7", "2.19") to avoid
-# misclassifying pre-release/build metadata strings like "3.7-rc".
-_TWO_PART_RE = re.compile(r'^\d+\.\d+$')
-
-
-def _classify_version(version: str) -> str:
-    """Classify a version string into a known category for dispatch.
-
-    Returns one of: 'origin_prefixed', 'main_alias', 'three_part', 'two_part', 'unknown'.
-    """
-    if version.startswith('origin/'):
-        return 'origin_prefixed'
-    if version.lower() in ('main', 'latest'):
-        return 'main_alias'
-    try:
-        semver.Version.parse(version)
-        return 'three_part'
-    except (ValueError, TypeError):
-        pass
-    if _TWO_PART_RE.match(version):
-        try:
-            semver.Version.parse(f'{version}.0')
-            return 'two_part'
-        except (ValueError, TypeError):
-            pass
-    return 'unknown'
-
-
-def resolve_version_tag(version: str) -> str:
-    """Map a user-provided version string to the canonical project.tag format.
-
-    The scans index stores release branch tags as ``origin/{major}.{minor}``
-    and specific release version tags as three-part semver (e.g., ``2.19.6``).
-
-    Mapping rules:
-      - Already prefixed with ``"origin/"`` → returned as-is
-      - ``"main"`` or ``"latest"`` → ``"origin/main"``
-      - Two-part version (e.g., ``"3.7"``) → ``"origin/3.7"`` (branch tag)
-      - Three-part version (e.g., ``"3.7.0"``, ``"2.19.6"``) → ``"origin/3.7"``, ``"origin/2.19"`` (branch tag)
-      - Non-parseable input → returned as-is (for exact tag lookups)
-
-    Args:
-        version: User-provided version or tag string.
-
-    Returns:
-        The canonical tag string to use in queries.
-    """
-    if not version:
-        return version
-
-    match _classify_version(version):
-        case 'origin_prefixed':
-            resolved = version
-        case 'main_alias':
-            resolved = 'origin/main'
-        case 'three_part':
-            parsed = semver.Version.parse(version)
-            resolved = f'origin/{parsed.major}.{parsed.minor}'
-        case 'two_part':
-            resolved = f'origin/{version}'
-        case _:
-            resolved = version
-
-    logger.info(f"RESOLVE_TAG: '{version}' -> '{resolved}'")
-    return resolved
 
 
 def _build_dsl_query(
@@ -189,54 +122,6 @@ def _execute_query(index: str, query_body: str) -> Dict[str, Any]:
     return result
 
 
-def _error_response(
-    error_type: str,
-    message: str,
-    status_code: Optional[int] = None,
-) -> Dict[str, Any]:
-    """Return a consistent error response dict.
-
-    Args:
-        error_type: Category of the error (e.g., opensearch_error, connection_error).
-        message: Human-readable error description.
-        status_code: Optional HTTP status code from OpenSearch.
-
-    Returns:
-        Error dict with status, type, retryable, message, and optional status_code.
-    """
-    error = {
-        'status': 'error',
-        'type': error_type,
-        'retryable': False,
-        'message': message,
-    }
-
-    if status_code is not None:
-        error['status_code'] = status_code
-
-    return error
-
-
-def _connection_error(exception: Exception) -> Dict[str, Any]:
-    """Return a connection error without leaking internal details.
-
-    Logs the original exception internally for diagnostics, then returns
-    a sanitized error dict via _error_response for consistent structure.
-
-    Args:
-        exception: The caught exception from the connection failure.
-
-    Returns:
-        Sanitized error dict with consistent structure.
-    """
-    logger.error(f'CONNECTION_ERROR: {type(exception).__name__}: {exception}')
-    return _error_response(
-        'connection_error',
-        'Failed to connect to the OpenSearch cluster. '
-        'The service may be temporarily unavailable.',
-    )
-
-
 def query_vulnerabilities(
     version: Optional[str] = None,
     project_name: Optional[str] = None,
@@ -262,7 +147,7 @@ def query_vulnerabilities(
             f'SECURITY_ADVISORIES_DSL_QUERY_FAILED: '
             f'Could not resolve scans index: {e}',
         )
-        return _error_response('index_resolution_error', str(e))
+        return error_response('index_resolution_error', str(e))
 
     # Resolve version tag:
     # - version provided → resolve to canonical tag format
@@ -303,7 +188,7 @@ def query_vulnerabilities(
             logger.error(
                 f'SECURITY_ADVISORIES_DSL_QUERY_FAILED: {error_msg}',
             )
-            return _error_response(
+            return error_response(
                 'opensearch_error',
                 f'OpenSearch query failed: {error_msg}',
                 status_code=status_code,
@@ -313,7 +198,7 @@ def query_vulnerabilities(
         logger.error(
             f'SECURITY_ADVISORIES_DSL_QUERY_FAILED: {error_msg}',
         )
-        return _connection_error(e)
+        return connection_error(e)
 
     return result
 

--- a/agents/security_advisories/lambda/dsl_query_builder.py
+++ b/agents/security_advisories/lambda/dsl_query_builder.py
@@ -147,7 +147,7 @@ def query_vulnerabilities(
             f'SECURITY_ADVISORIES_DSL_QUERY_FAILED: '
             f'Could not resolve scans index: {e}',
         )
-        return error_response('index_resolution_error', str(e))
+        return error_response('index_resolution_error', 'Failed to resolve scans index.')
 
     # Resolve version tag:
     # - version provided → resolve to canonical tag format

--- a/agents/security_advisories/lambda/dsl_query_builder.py
+++ b/agents/security_advisories/lambda/dsl_query_builder.py
@@ -190,7 +190,7 @@ def query_vulnerabilities(
             )
             return error_response(
                 'opensearch_error',
-                f'OpenSearch query failed: {error_msg}',
+                'OpenSearch query failed.',
                 status_code=status_code,
             )
 

--- a/agents/security_advisories/lambda/lambda_function.py
+++ b/agents/security_advisories/lambda/lambda_function.py
@@ -9,6 +9,8 @@ appropriate handler based on the function name in the event:
 
 - ``query_vulnerabilities`` → vulnerabilities_handler
 - ``list_projects`` → projects_handler
+- ``query_tickets`` → tickets_handler
+- ``list_ticket_projects`` → tickets_handler
 
 All results are wrapped in the Bedrock response envelope via
 ``create_response()``.
@@ -26,12 +28,13 @@ from typing import Any, Dict, List
 from config import config
 from projects_handler import handle_list_projects
 from response_builder import create_response
+from tickets_handler import handle_list_ticket_projects, handle_query_tickets
 from vulnerabilities_handler import handle_query_vulnerabilities
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-AVAILABLE_FUNCTIONS = ['query_vulnerabilities', 'list_projects']
+AVAILABLE_FUNCTIONS = ['query_vulnerabilities', 'list_projects', 'query_tickets', 'list_ticket_projects']
 
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
@@ -66,6 +69,10 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             result = handle_query_vulnerabilities(params, request_id)
         elif function_name == 'list_projects':
             result = handle_list_projects(request_id)
+        elif function_name == 'query_tickets':
+            result = handle_query_tickets(params, request_id)
+        elif function_name == 'list_ticket_projects':
+            result = handle_list_ticket_projects(request_id)
         else:
             result = {
                 'status': 'error',

--- a/agents/security_advisories/lambda/query_utils.py
+++ b/agents/security_advisories/lambda/query_utils.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared utilities for Security Advisories query modules.
+
+This module provides common helpers used across the DSL query builder and
+tickets query builder, including version/tag resolution and standardized
+error response construction.
+
+Functions:
+    resolve_version_tag: Map user-provided version to canonical tag format
+    error_response: Return a consistent error response dict
+    connection_error: Return a sanitized connection error response
+"""
+
+import logging
+import re
+from typing import Any, Dict, Optional
+
+import semver
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# Strict two-part numeric pattern (e.g., "3.7", "2.19") to avoid
+# misclassifying pre-release/build metadata strings like "3.7-rc".
+_TWO_PART_RE = re.compile(r'^\d+\.\d+$')
+
+
+def _classify_version(version: str) -> str:
+    """Classify a version string into a known category for dispatch.
+
+    Returns one of: 'origin_prefixed', 'main_alias', 'three_part', 'two_part', 'unknown'.
+    """
+    if version.startswith('origin/'):
+        return 'origin_prefixed'
+    if version.lower() in ('main', 'latest'):
+        return 'main_alias'
+    try:
+        semver.Version.parse(version)
+        return 'three_part'
+    except (ValueError, TypeError):
+        pass
+    if _TWO_PART_RE.match(version):
+        try:
+            semver.Version.parse(f'{version}.0')
+            return 'two_part'
+        except (ValueError, TypeError):
+            pass
+    return 'unknown'
+
+
+def resolve_version_tag(version: str) -> str:
+    """Map a user-provided version string to the canonical project.tag format.
+
+    The scans and tickets indices store release branch tags as
+    ``origin/{major}.{minor}`` and specific release version tags as
+    three-part semver (e.g., ``2.19.6``).
+
+    Mapping rules:
+      - Already prefixed with ``"origin/"`` → returned as-is
+      - ``"main"`` or ``"latest"`` → ``"origin/main"``
+      - Two-part version (e.g., ``"3.7"``) → ``"origin/3.7"`` (branch tag)
+      - Three-part version (e.g., ``"3.7.0"``, ``"2.19.6"``) → ``"origin/3.7"``, ``"origin/2.19"`` (branch tag)
+      - Non-parseable input → returned as-is (for exact tag lookups)
+
+    Args:
+        version: User-provided version or tag string.
+
+    Returns:
+        The canonical tag string to use in queries.
+    """
+    if not version:
+        return version
+
+    match _classify_version(version):
+        case 'origin_prefixed':
+            resolved = version
+        case 'main_alias':
+            resolved = 'origin/main'
+        case 'three_part':
+            parsed = semver.Version.parse(version)
+            resolved = f'origin/{parsed.major}.{parsed.minor}'
+        case 'two_part':
+            resolved = f'origin/{version}'
+        case _:
+            resolved = version
+
+    logger.info(f"RESOLVE_TAG: '{version}' -> '{resolved}'")
+    return resolved
+
+
+def error_response(
+    error_type: str,
+    message: str,
+    status_code: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Return a consistent error response dict.
+
+    Args:
+        error_type: Category of the error (e.g., opensearch_error, connection_error).
+        message: Human-readable error description.
+        status_code: Optional HTTP status code from OpenSearch.
+
+    Returns:
+        Error dict with status, type, retryable, message, and optional status_code.
+    """
+    error: Dict[str, Any] = {
+        'status': 'error',
+        'type': error_type,
+        'retryable': False,
+        'message': message,
+    }
+
+    if status_code is not None:
+        error['status_code'] = status_code
+
+    return error
+
+
+def connection_error(exception: Exception) -> Dict[str, Any]:
+    """Return a connection error without leaking internal details.
+
+    Logs the original exception internally for diagnostics, then returns
+    a sanitized error dict via error_response for consistent structure.
+
+    Args:
+        exception: The caught exception from the connection failure.
+
+    Returns:
+        Sanitized error dict with consistent structure.
+    """
+    logger.error(f'CONNECTION_ERROR: {type(exception).__name__}: {exception}')
+    return error_response(
+        'connection_error',
+        'Failed to connect to the OpenSearch cluster. '
+        'The service may be temporarily unavailable.',
+    )

--- a/agents/security_advisories/lambda/tickets_handler.py
+++ b/agents/security_advisories/lambda/tickets_handler.py
@@ -67,8 +67,7 @@ def handle_query_tickets(params: Dict[str, str], request_id: str) -> Dict[str, A
                 "- **cve_id**: A specific CVE identifier (e.g. CVE-2024-12345)\n"
                 "- **project_name**: A project name (e.g. OpenSearch)\n"
                 "- **branch**: A branch or version (e.g. 2.19 or main)\n\n"
-                "You can also use `list_ticket_projects` to see which projects "
-                "have assigned tickets."
+                "I can also list which projects currently have assigned tickets."
             ),
         }
 
@@ -129,9 +128,8 @@ def handle_list_ticket_projects(request_id: str) -> Dict[str, Any]:
     try:
         result = opensearch_request('GET', f'/{TICKETS_INDEX}/_search', body=query_body)
     except RuntimeError as e:
-        error_message = str(e)
-        logger.error(f"[{request_id}] LIST_TICKET_PROJECTS_FAILED: {error_message}")
-        return error_response('opensearch_error', error_message)
+        logger.error(f"[{request_id}] LIST_TICKET_PROJECTS_FAILED: {e}")
+        return error_response('opensearch_error', 'OpenSearch query failed.')
     except Exception as e:
         logger.error(
             f"[{request_id}] LIST_TICKET_PROJECTS_FAILED: {type(e).__name__}: {e}",

--- a/agents/security_advisories/lambda/tickets_handler.py
+++ b/agents/security_advisories/lambda/tickets_handler.py
@@ -18,6 +18,7 @@ import logging
 from typing import Any, Dict
 
 from aws_utils import opensearch_request
+from query_utils import connection_error, error_response
 from tickets_query_builder import (build_list_projects_query,
                                    build_tickets_query)
 
@@ -54,6 +55,23 @@ def handle_query_tickets(params: Dict[str, str], request_id: str) -> Dict[str, A
         f"project_name={project_name}, branch={branch}",
     )
 
+    if not cve_id and not project_name and not branch:
+        logger.info(f"[{request_id}] QUERY_TICKETS: No filters provided, requesting user input")
+        return {
+            'status': 'success',
+            'result_count': 0,
+            'results': [],
+            'message': (
+                "Please provide at least one filter to query tickets. "
+                "You can filter by:\n"
+                "- **cve_id**: A specific CVE identifier (e.g. CVE-2024-12345)\n"
+                "- **project_name**: A project name (e.g. OpenSearch)\n"
+                "- **branch**: A branch or version (e.g. 2.19 or main)\n\n"
+                "You can also use `list_ticket_projects` to see which projects "
+                "have assigned tickets."
+            ),
+        }
+
     query_body_dict = build_tickets_query(
         cve_id=cve_id, project_name=project_name, branch=branch,
     )
@@ -61,20 +79,15 @@ def handle_query_tickets(params: Dict[str, str], request_id: str) -> Dict[str, A
 
     try:
         result = opensearch_request('GET', f'/{TICKETS_INDEX}/_search', body=query_body)
-    except Exception as e:
+    except RuntimeError as e:
         error_message = str(e)
         logger.error(f"[{request_id}] QUERY_TICKETS_FAILED: {error_message}")
-        if "OpenSearch request failed:" in error_message:
-            return {
-                'status': 'error',
-                'type': 'opensearch_error',
-                'message': error_message,
-            }
-        return {
-            'status': 'error',
-            'type': 'connection_error',
-            'message': error_message,
-        }
+        return error_response('opensearch_error', error_message)
+    except Exception as e:
+        logger.error(
+            f"[{request_id}] QUERY_TICKETS_FAILED: {type(e).__name__}: {e}",
+        )
+        return connection_error(e)
 
     hits = result.get('hits', {}).get('hits', [])
     results = []
@@ -116,20 +129,15 @@ def handle_list_ticket_projects(request_id: str) -> Dict[str, Any]:
 
     try:
         result = opensearch_request('GET', f'/{TICKETS_INDEX}/_search', body=query_body)
-    except Exception as e:
+    except RuntimeError as e:
         error_message = str(e)
         logger.error(f"[{request_id}] LIST_TICKET_PROJECTS_FAILED: {error_message}")
-        if "OpenSearch request failed:" in error_message:
-            return {
-                'status': 'error',
-                'type': 'opensearch_error',
-                'message': error_message,
-            }
-        return {
-            'status': 'error',
-            'type': 'connection_error',
-            'message': error_message,
-        }
+        return error_response('opensearch_error', error_message)
+    except Exception as e:
+        logger.error(
+            f"[{request_id}] LIST_TICKET_PROJECTS_FAILED: {type(e).__name__}: {e}",
+        )
+        return connection_error(e)
 
     hits = result.get('hits', {}).get('hits', [])
     projects = [

--- a/agents/security_advisories/lambda/tickets_handler.py
+++ b/agents/security_advisories/lambda/tickets_handler.py
@@ -80,9 +80,8 @@ def handle_query_tickets(params: Dict[str, str], request_id: str) -> Dict[str, A
     try:
         result = opensearch_request('GET', f'/{TICKETS_INDEX}/_search', body=query_body)
     except RuntimeError as e:
-        error_message = str(e)
-        logger.error(f"[{request_id}] QUERY_TICKETS_FAILED: {error_message}")
-        return error_response('opensearch_error', error_message)
+        logger.error(f"[{request_id}] QUERY_TICKETS_FAILED: {e}")
+        return error_response('opensearch_error', 'OpenSearch query failed.')
     except Exception as e:
         logger.error(
             f"[{request_id}] QUERY_TICKETS_FAILED: {type(e).__name__}: {e}",

--- a/agents/security_advisories/lambda/tickets_handler.py
+++ b/agents/security_advisories/lambda/tickets_handler.py
@@ -77,13 +77,15 @@ def handle_query_tickets(params: Dict[str, str], request_id: str) -> Dict[str, A
         }
 
     hits = result.get('hits', {}).get('hits', [])
-    results = [
-        {
-            "ticketId": hit["_source"]["ticketId"],
-            "ticket_url": f'{_TICKET_URL_PREFIX}{hit["_source"]["ticketId"]}',
-        }
-        for hit in hits
-    ]
+    results = []
+    for hit in hits:
+        ticket_id = hit.get("_source", {}).get("ticketId")
+        if not ticket_id:
+            continue
+        results.append({
+            "ticketId": ticket_id,
+            "ticket_url": f'{_TICKET_URL_PREFIX}{ticket_id}',
+        })
 
     logger.info(f"[{request_id}] QUERY_TICKETS: Found {len(results)} ticket(s)")
 
@@ -130,7 +132,11 @@ def handle_list_ticket_projects(request_id: str) -> Dict[str, Any]:
         }
 
     hits = result.get('hits', {}).get('hits', [])
-    projects = [hit["_source"]["projectName"] for hit in hits]
+    projects = [
+        hit.get("_source", {}).get("projectName")
+        for hit in hits
+        if hit.get("_source", {}).get("projectName")
+    ]
 
     logger.info(f"[{request_id}] LIST_TICKET_PROJECTS: Found {len(projects)} project(s)")
 

--- a/agents/security_advisories/lambda/tickets_handler.py
+++ b/agents/security_advisories/lambda/tickets_handler.py
@@ -75,6 +75,7 @@ def handle_query_tickets(params: Dict[str, str], request_id: str) -> Dict[str, A
         cve_id=cve_id, project_name=project_name, branch=branch,
     )
     query_body = json.dumps(query_body_dict)
+    logger.info(f"[{request_id}] QUERY_TICKETS_DSL: {query_body}")
 
     try:
         result = opensearch_request('GET', f'/{TICKETS_INDEX}/_search', body=query_body)

--- a/agents/security_advisories/lambda/tickets_handler.py
+++ b/agents/security_advisories/lambda/tickets_handler.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tickets Handler for Security Advisories Lambda Functions.
+
+This module handles ticket query requests against the tickets OpenSearch index.
+It supports querying tickets by CVE ID, project name, or branch, and listing
+projects that have assigned tickets.
+
+Functions:
+    handle_query_tickets: Handle query_tickets requests
+    handle_list_ticket_projects: Handle list_ticket_projects requests
+"""
+
+import json
+import logging
+from typing import Any, Dict
+
+from aws_utils import opensearch_request
+from tickets_query_builder import (build_list_projects_query,
+                                   build_tickets_query)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+TICKETS_INDEX = "tickets"
+_TICKET_URL_PREFIX = "https://t.corp.amazon.com/"
+
+
+def handle_query_tickets(params: Dict[str, str], request_id: str) -> Dict[str, Any]:
+    """Handle query_tickets requests.
+
+    Extracts query parameters, builds a DSL query via the tickets query builder,
+    executes it against the tickets index, and returns structured results.
+
+    Args:
+        params: Parameters dict containing optional keys:
+            - cve_id (str): CVE identifier to filter tickets.
+            - project_name (str): Project name to filter tickets.
+            - branch (str): Branch name to filter tickets.
+        request_id: Short request ID for log correlation.
+
+    Returns:
+        On success: {"status": "success", "result_count": N, "results": [...]}
+        On error: {"status": "error", "type": "...", "message": "..."}
+    """
+    cve_id = params.get('cve_id')
+    project_name = params.get('project_name')
+    branch = params.get('branch')
+
+    logger.info(
+        f"[{request_id}] QUERY_TICKETS: cve_id={cve_id}, "
+        f"project_name={project_name}, branch={branch}",
+    )
+
+    query_body_dict = build_tickets_query(
+        cve_id=cve_id, project_name=project_name, branch=branch,
+    )
+    query_body = json.dumps(query_body_dict)
+
+    try:
+        result = opensearch_request('GET', f'/{TICKETS_INDEX}/_search', body=query_body)
+    except Exception as e:
+        error_message = str(e)
+        logger.error(f"[{request_id}] QUERY_TICKETS_FAILED: {error_message}")
+        if "OpenSearch request failed:" in error_message:
+            return {
+                'status': 'error',
+                'type': 'opensearch_error',
+                'message': error_message,
+            }
+        return {
+            'status': 'error',
+            'type': 'connection_error',
+            'message': error_message,
+        }
+
+    hits = result.get('hits', {}).get('hits', [])
+    results = [
+        {
+            "ticketId": hit["_source"]["ticketId"],
+            "ticket_url": f'{_TICKET_URL_PREFIX}{hit["_source"]["ticketId"]}',
+        }
+        for hit in hits
+    ]
+
+    logger.info(f"[{request_id}] QUERY_TICKETS: Found {len(results)} ticket(s)")
+
+    return {
+        'status': 'success',
+        'result_count': len(results),
+        'results': results,
+    }
+
+
+def handle_list_ticket_projects(request_id: str) -> Dict[str, Any]:
+    """Handle list_ticket_projects requests.
+
+    Builds a collapsed query to find unique project names with assigned tickets,
+    executes it against the tickets index, and returns the project list.
+
+    Args:
+        request_id: Short request ID for log correlation.
+
+    Returns:
+        On success: {"status": "success", "projects": [...]}
+        On error: {"status": "error", "type": "...", "message": "..."}
+    """
+    logger.info(f"[{request_id}] LIST_TICKET_PROJECTS: Listing projects with assigned tickets")
+
+    query_body_dict = build_list_projects_query()
+    query_body = json.dumps(query_body_dict)
+
+    try:
+        result = opensearch_request('GET', f'/{TICKETS_INDEX}/_search', body=query_body)
+    except Exception as e:
+        error_message = str(e)
+        logger.error(f"[{request_id}] LIST_TICKET_PROJECTS_FAILED: {error_message}")
+        if "OpenSearch request failed:" in error_message:
+            return {
+                'status': 'error',
+                'type': 'opensearch_error',
+                'message': error_message,
+            }
+        return {
+            'status': 'error',
+            'type': 'connection_error',
+            'message': error_message,
+        }
+
+    hits = result.get('hits', {}).get('hits', [])
+    projects = [hit["_source"]["projectName"] for hit in hits]
+
+    logger.info(f"[{request_id}] LIST_TICKET_PROJECTS: Found {len(projects)} project(s)")
+
+    return {
+        'status': 'success',
+        'projects': projects,
+    }

--- a/agents/security_advisories/lambda/tickets_query_builder.py
+++ b/agents/security_advisories/lambda/tickets_query_builder.py
@@ -16,6 +16,8 @@ Functions:
 import logging
 from typing import Any, Dict, Optional
 
+from query_utils import resolve_version_tag
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -39,7 +41,7 @@ def build_tickets_query(
     Conditional filters added when parameters are provided:
     - If cve_id provided: adds {"term": {"cveId": cve_id}}
     - If project_name provided: adds {"term": {"projectName": project_name}}
-    - If branch provided: adds {"term": {"branches": branch}}
+    - If branch provided: resolves via resolve_version_tag, then adds {"term": {"branches": resolved_branch}}
     - If none provided: uses match_all query with mandatory status filter
 
     Args:
@@ -59,6 +61,7 @@ def build_tickets_query(
         filters.append({'term': {'projectName': project_name}})
 
     if branch:
+        branch = resolve_version_tag(branch)
         filters.append({'term': {'branches': branch}})
 
     sort = [{'timestamp.created': {'order': 'desc'}}]

--- a/agents/security_advisories/lambda/tickets_query_builder.py
+++ b/agents/security_advisories/lambda/tickets_query_builder.py
@@ -39,7 +39,8 @@ def build_tickets_query(
     - size: 1000
 
     Conditional filters added when parameters are provided:
-    - If cve_id provided: adds {"term": {"cveId": cve_id}}
+    - If cve_id provided: adds bool/should matching either {"term": {"cveId": cve_id}}
+      or {"term": {"cveIds.keyword": cve_id}}, and limits size to 1 (most recent ticket).
     - If project_name provided: adds {"term": {"projectName": project_name}}
     - If branch provided: resolves via resolve_version_tag, then adds {"term": {"branches": resolved_branch}}
     - If none provided: uses bool/filter with only the mandatory status filter
@@ -55,7 +56,15 @@ def build_tickets_query(
     filters = [{'term': {'status': 'Assigned'}}]
 
     if cve_id:
-        filters.append({'term': {'cveId': cve_id}})
+        filters.append({
+            'bool': {
+                'should': [
+                    {'term': {'cveId': cve_id}},
+                    {'term': {'cveIds.keyword': cve_id}},
+                ],
+                'minimum_should_match': 1,
+            },
+        })
 
     if project_name:
         filters.append({'term': {'projectName': project_name}})
@@ -65,9 +74,10 @@ def build_tickets_query(
         filters.append({'term': {'branches': branch}})
 
     sort = [{'timestamp.created': {'order': 'desc'}}]
+    size = 1 if cve_id else _DEFAULT_QUERY_SIZE
 
     query = {
-        'size': _DEFAULT_QUERY_SIZE,
+        'size': size,
         '_source': ['ticketId'],
         'sort': sort,
         'query': {

--- a/agents/security_advisories/lambda/tickets_query_builder.py
+++ b/agents/security_advisories/lambda/tickets_query_builder.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""DSL Query Builder for Tickets Index Queries.
+
+This module constructs OpenSearch Query DSL bodies for querying the tickets
+index. It supports filtering by CVE identifier, project name, and branch,
+and always applies a mandatory status filter for assigned tickets.
+
+Functions:
+    build_tickets_query: Construct a DSL query to find tickets by CVE, project, or branch.
+    build_list_projects_query: Construct a DSL query to list unique projects with assigned tickets.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# Default query size — matches the existing codebase configuration
+_DEFAULT_QUERY_SIZE = 1000
+
+
+def build_tickets_query(
+    cve_id: Optional[str] = None,
+    project_name: Optional[str] = None,
+    branch: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build DSL query for the tickets index.
+
+    Always includes:
+    - term filter: {"status": "Assigned"}
+    - sort: [{"timestamp.created": {"order": "desc"}}]
+    - _source: ["ticketId"]
+    - size: 1000
+
+    Conditional filters added when parameters are provided:
+    - If cve_id provided: adds {"term": {"cveId": cve_id}}
+    - If project_name provided: adds {"term": {"projectName": project_name}}
+    - If branch provided: adds {"term": {"branches": branch}}
+    - If none provided: uses match_all query with mandatory status filter
+
+    Args:
+        cve_id: Optional CVE identifier to filter tickets (e.g., "CVE-2026-27903").
+        project_name: Optional project or component name to filter tickets.
+        branch: Optional branch name to filter tickets (e.g., "origin/main").
+
+    Returns:
+        A dict representing the OpenSearch query body, ready for json.dumps().
+    """
+    filters = [{'term': {'status': 'Assigned'}}]
+
+    if cve_id:
+        filters.append({'term': {'cveId': cve_id}})
+
+    if project_name:
+        filters.append({'term': {'projectName': project_name}})
+
+    if branch:
+        filters.append({'term': {'branches': branch}})
+
+    sort = [{'timestamp.created': {'order': 'desc'}}]
+
+    # When no optional filters are provided, use match_all with the
+    # mandatory status filter. Otherwise, use bool/filter with all clauses.
+    has_optional_filters = any([cve_id, project_name, branch])
+
+    if has_optional_filters:
+        query = {
+            'size': _DEFAULT_QUERY_SIZE,
+            '_source': ['ticketId'],
+            'sort': sort,
+            'query': {
+                'bool': {
+                    'filter': filters,
+                },
+            },
+        }
+    else:
+        query = {
+            'size': _DEFAULT_QUERY_SIZE,
+            '_source': ['ticketId'],
+            'sort': sort,
+            'query': {
+                'bool': {
+                    'must': {'match_all': {}},
+                    'filter': filters,
+                },
+            },
+        }
+
+    logger.info(f'TICKETS_QUERY: Built query with {len(filters)} filter(s)')
+    return query
+
+
+def build_list_projects_query() -> Dict[str, Any]:
+    """Build DSL query to list unique projects with assigned tickets.
+
+    Uses:
+    - match_all query
+    - term filter: {"status": "Assigned"}
+    - collapse on "projectName" field
+    - _source: ["projectName"]
+    - size: 1000
+
+    Returns:
+        A dict representing the OpenSearch query body, ready for json.dumps().
+    """
+    query = {
+        'size': _DEFAULT_QUERY_SIZE,
+        '_source': ['projectName'],
+        'query': {
+            'bool': {
+                'must': {'match_all': {}},
+                'filter': [
+                    {'term': {'status': 'Assigned'}},
+                ],
+            },
+        },
+        'collapse': {'field': 'projectName'},
+    }
+
+    logger.info('TICKETS_QUERY: Built list_projects query')
+    return query

--- a/agents/security_advisories/lambda/tickets_query_builder.py
+++ b/agents/security_advisories/lambda/tickets_query_builder.py
@@ -42,7 +42,7 @@ def build_tickets_query(
     - If cve_id provided: adds {"term": {"cveId": cve_id}}
     - If project_name provided: adds {"term": {"projectName": project_name}}
     - If branch provided: resolves via resolve_version_tag, then adds {"term": {"branches": resolved_branch}}
-    - If none provided: uses match_all query with mandatory status filter
+    - If none provided: uses bool/filter with only the mandatory status filter
 
     Args:
         cve_id: Optional CVE identifier to filter tickets (e.g., "CVE-2026-27903").
@@ -66,33 +66,16 @@ def build_tickets_query(
 
     sort = [{'timestamp.created': {'order': 'desc'}}]
 
-    # When no optional filters are provided, use match_all with the
-    # mandatory status filter. Otherwise, use bool/filter with all clauses.
-    has_optional_filters = any([cve_id, project_name, branch])
-
-    if has_optional_filters:
-        query = {
-            'size': _DEFAULT_QUERY_SIZE,
-            '_source': ['ticketId'],
-            'sort': sort,
-            'query': {
-                'bool': {
-                    'filter': filters,
-                },
+    query = {
+        'size': _DEFAULT_QUERY_SIZE,
+        '_source': ['ticketId'],
+        'sort': sort,
+        'query': {
+            'bool': {
+                'filter': filters,
             },
-        }
-    else:
-        query = {
-            'size': _DEFAULT_QUERY_SIZE,
-            '_source': ['ticketId'],
-            'sort': sort,
-            'query': {
-                'bool': {
-                    'must': {'match_all': {}},
-                    'filter': filters,
-                },
-            },
-        }
+        },
+    }
 
     logger.info(f'TICKETS_QUERY: Built query with {len(filters)} filter(s)')
     return query

--- a/tests/agents/security_advisories/lambda/test_dsl_query_builder.py
+++ b/tests/agents/security_advisories/lambda/test_dsl_query_builder.py
@@ -92,7 +92,7 @@ class TestIndexResolutionError:
         assert result['status'] == 'error'
         assert result['type'] == 'index_resolution_error'
         assert result['retryable'] is False
-        assert 'No scans indices found' in result['message']
+        assert result['message'] == 'Failed to resolve scans index.'
 
     def test_runtime_error_with_custom_message(self):
         """Validates: Requirement 1.7"""
@@ -107,7 +107,7 @@ class TestIndexResolutionError:
         assert result['status'] == 'error'
         assert result['type'] == 'index_resolution_error'
         assert result['retryable'] is False
-        assert 'timeout' in result['message']
+        assert result['message'] == 'Failed to resolve scans index.'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agents/security_advisories/lambda/test_tickets_query_builder.py
+++ b/tests/agents/security_advisories/lambda/test_tickets_query_builder.py
@@ -1,0 +1,199 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for security advisories tickets_query_builder.py.
+
+These tests verify DSL query construction for the tickets index,
+including filtering by CVE ID, project name, branch, and the
+match_all fallback when no parameters are provided.
+
+Validates: Requirements 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7
+"""
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# Path to the real tickets_query_builder module
+_LAMBDA_PATH = os.path.join(
+    os.path.dirname(__file__), '..', '..', '..', '..', 'agents', 'security_advisories', 'lambda',
+)
+
+
+def _load_tickets_query_builder():
+    """Import tickets_query_builder from security_advisories lambda with mocked deps.
+
+    Returns:
+        The loaded module with mocked aws_utils and config.
+    """
+    if _LAMBDA_PATH not in sys.path:
+        sys.path.insert(0, _LAMBDA_PATH)
+
+    mock_aws_utils = MagicMock()
+    mock_config_module = MagicMock()
+
+    with patch.dict('sys.modules', {
+        'aws_utils': mock_aws_utils,
+        'config': mock_config_module,
+    }):
+        spec = importlib.util.spec_from_file_location(
+            'sa_tickets_query_builder_unit',
+            os.path.join(_LAMBDA_PATH, 'tickets_query_builder.py'),
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Test: build_tickets_query with cve_id only
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTicketsQueryCveIdOnly:
+    """Test build_tickets_query with only cve_id parameter."""
+
+    def test_cve_id_only_produces_status_and_cve_filters(self):
+        """Validates: Requirements 4.1, 4.2"""
+        mod = _load_tickets_query_builder()
+
+        result = mod.build_tickets_query(cve_id='CVE-2026-27903')
+
+        assert result['size'] == 1000
+        assert result['_source'] == ['ticketId']
+        assert result['sort'] == [{'timestamp.created': {'order': 'desc'}}]
+
+        filters = result['query']['bool']['filter']
+        assert {'term': {'status': 'Assigned'}} in filters
+        assert {'term': {'cveId': 'CVE-2026-27903'}} in filters
+        assert len(filters) == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: build_tickets_query with project_name only
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTicketsQueryProjectNameOnly:
+    """Test build_tickets_query with only project_name parameter."""
+
+    def test_project_name_only_produces_status_and_project_filters(self):
+        """Validates: Requirements 4.1, 4.3"""
+        mod = _load_tickets_query_builder()
+
+        result = mod.build_tickets_query(project_name='OpenSearch Dashboards')
+
+        assert result['size'] == 1000
+        assert result['_source'] == ['ticketId']
+        assert result['sort'] == [{'timestamp.created': {'order': 'desc'}}]
+
+        filters = result['query']['bool']['filter']
+        assert {'term': {'status': 'Assigned'}} in filters
+        assert {'term': {'projectName': 'OpenSearch Dashboards'}} in filters
+        assert len(filters) == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: build_tickets_query with branch only
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTicketsQueryBranchOnly:
+    """Test build_tickets_query with only branch parameter."""
+
+    def test_branch_only_produces_status_and_branches_filters(self):
+        """Validates: Requirements 4.1, 4.4"""
+        mod = _load_tickets_query_builder()
+
+        result = mod.build_tickets_query(branch='origin/main')
+
+        assert result['size'] == 1000
+        assert result['_source'] == ['ticketId']
+        assert result['sort'] == [{'timestamp.created': {'order': 'desc'}}]
+
+        filters = result['query']['bool']['filter']
+        assert {'term': {'status': 'Assigned'}} in filters
+        assert {'term': {'branches': 'origin/main'}} in filters
+        assert len(filters) == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: build_tickets_query with all three parameters
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTicketsQueryAllParams:
+    """Test build_tickets_query with cve_id, project_name, and branch combined."""
+
+    def test_all_params_produces_four_filters(self):
+        """Validates: Requirements 4.1, 4.2, 4.3, 4.4"""
+        mod = _load_tickets_query_builder()
+
+        result = mod.build_tickets_query(
+            cve_id='CVE-2026-27903',
+            project_name='OpenSearch',
+            branch='origin/3.7',
+        )
+
+        assert result['size'] == 1000
+        assert result['_source'] == ['ticketId']
+        assert result['sort'] == [{'timestamp.created': {'order': 'desc'}}]
+
+        filters = result['query']['bool']['filter']
+        assert {'term': {'status': 'Assigned'}} in filters
+        assert {'term': {'cveId': 'CVE-2026-27903'}} in filters
+        assert {'term': {'projectName': 'OpenSearch'}} in filters
+        assert {'term': {'branches': 'origin/3.7'}} in filters
+        assert len(filters) == 4
+
+
+# ---------------------------------------------------------------------------
+# Test: build_tickets_query with no parameters (match_all fallback)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTicketsQueryNoParams:
+    """Test build_tickets_query with no parameters uses match_all."""
+
+    def test_no_params_uses_match_all_with_status_filter(self):
+        """Validates: Requirements 4.1, 4.5"""
+        mod = _load_tickets_query_builder()
+
+        result = mod.build_tickets_query()
+
+        assert result['size'] == 1000
+        assert result['_source'] == ['ticketId']
+        assert result['sort'] == [{'timestamp.created': {'order': 'desc'}}]
+
+        query = result['query']['bool']
+        assert query['must'] == {'match_all': {}}
+        filters = query['filter']
+        assert {'term': {'status': 'Assigned'}} in filters
+        assert len(filters) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test: build_list_projects_query
+# ---------------------------------------------------------------------------
+
+
+class TestBuildListProjectsQuery:
+    """Test build_list_projects_query returns correct structure."""
+
+    def test_list_projects_query_has_correct_structure(self):
+        """Validates: Requirements 4.1, 4.5, 4.6, 4.7"""
+        mod = _load_tickets_query_builder()
+
+        result = mod.build_list_projects_query()
+
+        assert result['size'] == 1000
+        assert result['_source'] == ['projectName']
+        assert result['collapse'] == {'field': 'projectName'}
+
+        query = result['query']['bool']
+        assert query['must'] == {'match_all': {}}
+        filters = query['filter']
+        assert {'term': {'status': 'Assigned'}} in filters
+        assert len(filters) == 1

--- a/tests/agents/security_advisories/lambda/test_tickets_query_builder.py
+++ b/tests/agents/security_advisories/lambda/test_tickets_query_builder.py
@@ -61,13 +61,23 @@ class TestBuildTicketsQueryCveIdOnly:
 
         result = mod.build_tickets_query(cve_id='CVE-2026-27903')
 
-        assert result['size'] == 1000
+        assert result['size'] == 1
         assert result['_source'] == ['ticketId']
         assert result['sort'] == [{'timestamp.created': {'order': 'desc'}}]
 
         filters = result['query']['bool']['filter']
         assert {'term': {'status': 'Assigned'}} in filters
-        assert {'term': {'cveId': 'CVE-2026-27903'}} in filters
+
+        expected_cve_filter = {
+            'bool': {
+                'should': [
+                    {'term': {'cveId': 'CVE-2026-27903'}},
+                    {'term': {'cveIds.keyword': 'CVE-2026-27903'}},
+                ],
+                'minimum_should_match': 1,
+            },
+        }
+        assert expected_cve_filter in filters
         assert len(filters) == 2
 
 
@@ -137,13 +147,23 @@ class TestBuildTicketsQueryAllParams:
             branch='origin/3.7',
         )
 
-        assert result['size'] == 1000
+        assert result['size'] == 1
         assert result['_source'] == ['ticketId']
         assert result['sort'] == [{'timestamp.created': {'order': 'desc'}}]
 
         filters = result['query']['bool']['filter']
         assert {'term': {'status': 'Assigned'}} in filters
-        assert {'term': {'cveId': 'CVE-2026-27903'}} in filters
+
+        expected_cve_filter = {
+            'bool': {
+                'should': [
+                    {'term': {'cveId': 'CVE-2026-27903'}},
+                    {'term': {'cveIds.keyword': 'CVE-2026-27903'}},
+                ],
+                'minimum_should_match': 1,
+            },
+        }
+        assert expected_cve_filter in filters
         assert {'term': {'projectName': 'OpenSearch'}} in filters
         assert {'term': {'branches': 'origin/3.7'}} in filters
         assert len(filters) == 4

--- a/tests/agents/security_advisories/lambda/test_tickets_query_builder.py
+++ b/tests/agents/security_advisories/lambda/test_tickets_query_builder.py
@@ -5,7 +5,7 @@
 
 These tests verify DSL query construction for the tickets index,
 including filtering by CVE ID, project name, branch, and the
-match_all fallback when no parameters are provided.
+no-parameters case where only the mandatory status filter applies.
 
 Validates: Requirements 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7
 """
@@ -150,14 +150,14 @@ class TestBuildTicketsQueryAllParams:
 
 
 # ---------------------------------------------------------------------------
-# Test: build_tickets_query with no parameters (match_all fallback)
+# Test: build_tickets_query with no parameters
 # ---------------------------------------------------------------------------
 
 
 class TestBuildTicketsQueryNoParams:
-    """Test build_tickets_query with no parameters uses match_all."""
+    """Test build_tickets_query with no parameters applies only the status filter."""
 
-    def test_no_params_uses_match_all_with_status_filter(self):
+    def test_no_params_produces_only_status_filter(self):
         """Validates: Requirements 4.1, 4.5"""
         mod = _load_tickets_query_builder()
 
@@ -167,11 +167,10 @@ class TestBuildTicketsQueryNoParams:
         assert result['_source'] == ['ticketId']
         assert result['sort'] == [{'timestamp.created': {'order': 'desc'}}]
 
-        query = result['query']['bool']
-        assert query['must'] == {'match_all': {}}
-        filters = query['filter']
+        filters = result['query']['bool']['filter']
         assert {'term': {'status': 'Assigned'}} in filters
         assert len(filters) == 1
+        assert 'must' not in result['query']['bool']
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agents/security_advisories/lambda/test_tickets_query_builder_properties.py
+++ b/tests/agents/security_advisories/lambda/test_tickets_query_builder_properties.py
@@ -126,13 +126,14 @@ class TestQueryStructureInvariant:
         branch=st.one_of(st.none(), st.text()),
     )
     @settings(max_examples=100)
-    def test_size_always_1000(self, cve_id, project_name, branch):
-        """The size is always 1000.
+    def test_size_correct(self, cve_id, project_name, branch):
+        """Size is 1 when cve_id is truthy (most recent ticket), 1000 otherwise.
 
         **Validates: Requirements 4.1**
         """
         query = build_tickets_query(cve_id=cve_id, project_name=project_name, branch=branch)
-        assert query['size'] == 1000, (
+        expected_size = 1 if cve_id else 1000
+        assert query['size'] == expected_size, (
             f'Size incorrect for inputs cve_id={cve_id!r}, '
             f'project_name={project_name!r}, branch={branch!r}'
         )
@@ -152,8 +153,18 @@ class TestQueryStructureInvariant:
         filters = query['query']['bool']['filter']
 
         if cve_id:
-            assert {'term': {'cveId': cve_id}} in filters, (
-                f'cveId filter missing when cve_id={cve_id!r}'
+            # cve_id uses a bool/should to match either cveId or cveIds.keyword
+            expected_cve_filter = {
+                'bool': {
+                    'should': [
+                        {'term': {'cveId': cve_id}},
+                        {'term': {'cveIds.keyword': cve_id}},
+                    ],
+                    'minimum_should_match': 1,
+                },
+            }
+            assert expected_cve_filter in filters, (
+                f'cveId bool/should filter missing when cve_id={cve_id!r}'
             )
 
         if project_name:

--- a/tests/agents/security_advisories/lambda/test_tickets_query_builder_properties.py
+++ b/tests/agents/security_advisories/lambda/test_tickets_query_builder_properties.py
@@ -1,0 +1,191 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Property-based tests for tickets_query_builder.py using Hypothesis.
+
+These tests verify universal correctness properties of the tickets DSL query
+builder module across many randomly generated inputs.
+"""
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+# Path to the real lambda module
+_LAMBDA_PATH = os.path.join(
+    os.path.dirname(__file__), '..', '..', '..', '..', 'agents', 'security_advisories', 'lambda',
+)
+
+
+def _load_tickets_query_builder():
+    """Import tickets_query_builder with mocked aws_utils and config."""
+    if _LAMBDA_PATH not in sys.path:
+        sys.path.insert(0, _LAMBDA_PATH)
+
+    mock_aws_utils = MagicMock()
+    mock_config_module = MagicMock()
+
+    with patch.dict('sys.modules', {
+        'aws_utils': mock_aws_utils,
+        'config': mock_config_module,
+    }):
+        spec = importlib.util.spec_from_file_location(
+            'tickets_query_builder', os.path.join(_LAMBDA_PATH, 'tickets_query_builder.py'),
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+
+# Load the module once for all tests
+_mod = _load_tickets_query_builder()
+build_tickets_query = _mod.build_tickets_query
+
+
+# ---------------------------------------------------------------------------
+# Feature: ticket-query, Property 1: Query structure invariant
+# ---------------------------------------------------------------------------
+
+
+class TestQueryStructureInvariant:
+    """Property 1: Query structure invariant — status filter and sort always present.
+
+    For any combination of cve_id, project_name, and branch (present or absent,
+    with any string value), the DSL query body produced by build_tickets_query
+    SHALL always contain:
+    - A term filter {"term": {"status": "Assigned"}} in the filter clause
+    - A sort clause [{"timestamp.created": {"order": "desc"}}]
+    - A _source field of ["ticketId"]
+    - A size of 1000
+    - When cve_id is truthy: {"term": {"cveId": cve_id}} in filters
+    - When project_name is truthy: {"term": {"projectName": project_name}} in filters
+    - When branch is truthy: {"term": {"branches": branch}} in filters
+
+    **Validates: Requirements 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 1.1, 2.1, 8.1**
+    """
+
+    @given(
+        cve_id=st.one_of(st.none(), st.text()),
+        project_name=st.one_of(st.none(), st.text()),
+        branch=st.one_of(st.none(), st.text()),
+    )
+    @settings(max_examples=100)
+    def test_status_filter_always_present(self, cve_id, project_name, branch):
+        """The mandatory status filter is always present in the query.
+
+        **Validates: Requirements 4.1**
+        """
+        query = build_tickets_query(cve_id=cve_id, project_name=project_name, branch=branch)
+        filters = query['query']['bool']['filter']
+        assert {'term': {'status': 'Assigned'}} in filters, (
+            f'Status filter missing for inputs cve_id={cve_id!r}, '
+            f'project_name={project_name!r}, branch={branch!r}'
+        )
+
+    @given(
+        cve_id=st.one_of(st.none(), st.text()),
+        project_name=st.one_of(st.none(), st.text()),
+        branch=st.one_of(st.none(), st.text()),
+    )
+    @settings(max_examples=100)
+    def test_sort_always_present(self, cve_id, project_name, branch):
+        """The sort clause is always present in the query.
+
+        **Validates: Requirements 4.7**
+        """
+        query = build_tickets_query(cve_id=cve_id, project_name=project_name, branch=branch)
+        assert query['sort'] == [{'timestamp.created': {'order': 'desc'}}], (
+            f'Sort clause incorrect for inputs cve_id={cve_id!r}, '
+            f'project_name={project_name!r}, branch={branch!r}'
+        )
+
+    @given(
+        cve_id=st.one_of(st.none(), st.text()),
+        project_name=st.one_of(st.none(), st.text()),
+        branch=st.one_of(st.none(), st.text()),
+    )
+    @settings(max_examples=100)
+    def test_source_always_ticket_id_only(self, cve_id, project_name, branch):
+        """The _source field is always ["ticketId"].
+
+        **Validates: Requirements 4.6**
+        """
+        query = build_tickets_query(cve_id=cve_id, project_name=project_name, branch=branch)
+        assert query['_source'] == ['ticketId'], (
+            f'_source incorrect for inputs cve_id={cve_id!r}, '
+            f'project_name={project_name!r}, branch={branch!r}'
+        )
+
+    @given(
+        cve_id=st.one_of(st.none(), st.text()),
+        project_name=st.one_of(st.none(), st.text()),
+        branch=st.one_of(st.none(), st.text()),
+    )
+    @settings(max_examples=100)
+    def test_size_always_1000(self, cve_id, project_name, branch):
+        """The size is always 1000.
+
+        **Validates: Requirements 4.1**
+        """
+        query = build_tickets_query(cve_id=cve_id, project_name=project_name, branch=branch)
+        assert query['size'] == 1000, (
+            f'Size incorrect for inputs cve_id={cve_id!r}, '
+            f'project_name={project_name!r}, branch={branch!r}'
+        )
+
+    @given(
+        cve_id=st.one_of(st.none(), st.text()),
+        project_name=st.one_of(st.none(), st.text()),
+        branch=st.one_of(st.none(), st.text()),
+    )
+    @settings(max_examples=100)
+    def test_conditional_filters_present_when_truthy(self, cve_id, project_name, branch):
+        """Conditional term filters are present when their parameter is truthy.
+
+        **Validates: Requirements 4.2, 4.3, 4.4, 1.1, 2.1, 8.1**
+        """
+        query = build_tickets_query(cve_id=cve_id, project_name=project_name, branch=branch)
+        filters = query['query']['bool']['filter']
+
+        if cve_id:
+            assert {'term': {'cveId': cve_id}} in filters, (
+                f'cveId filter missing when cve_id={cve_id!r}'
+            )
+
+        if project_name:
+            assert {'term': {'projectName': project_name}} in filters, (
+                f'projectName filter missing when project_name={project_name!r}'
+            )
+
+        if branch:
+            assert {'term': {'branches': branch}} in filters, (
+                f'branches filter missing when branch={branch!r}'
+            )
+
+    @given(
+        cve_id=st.one_of(st.none(), st.text()),
+        project_name=st.one_of(st.none(), st.text()),
+        branch=st.one_of(st.none(), st.text()),
+    )
+    @settings(max_examples=100)
+    def test_match_all_when_no_optional_filters(self, cve_id, project_name, branch):
+        """match_all is used when no optional filters are provided.
+
+        **Validates: Requirements 4.5**
+        """
+        query = build_tickets_query(cve_id=cve_id, project_name=project_name, branch=branch)
+        has_optional = any([cve_id, project_name, branch])
+
+        if not has_optional:
+            assert query['query']['bool'].get('must') == {'match_all': {}}, (
+                'match_all should be present when no optional filters are provided'
+            )
+        else:
+            # When optional filters are provided, match_all should NOT be present
+            assert 'must' not in query['query']['bool'], (
+                'match_all should NOT be present when optional filters are provided'
+            )

--- a/tests/agents/security_advisories/lambda/test_tickets_query_builder_properties.py
+++ b/tests/agents/security_advisories/lambda/test_tickets_query_builder_properties.py
@@ -172,20 +172,12 @@ class TestQueryStructureInvariant:
         branch=st.one_of(st.none(), st.text()),
     )
     @settings(max_examples=100)
-    def test_match_all_when_no_optional_filters(self, cve_id, project_name, branch):
-        """match_all is used when no optional filters are provided.
+    def test_no_must_clause_present(self, cve_id, project_name, branch):
+        """The query never contains a must clause — bool/filter is sufficient.
 
         **Validates: Requirements 4.5**
         """
         query = build_tickets_query(cve_id=cve_id, project_name=project_name, branch=branch)
-        has_optional = any([cve_id, project_name, branch])
-
-        if not has_optional:
-            assert query['query']['bool'].get('must') == {'match_all': {}}, (
-                'match_all should be present when no optional filters are provided'
-            )
-        else:
-            # When optional filters are provided, match_all should NOT be present
-            assert 'must' not in query['query']['bool'], (
-                'match_all should NOT be present when optional filters are provided'
-            )
+        assert 'must' not in query['query']['bool'], (
+            'must clause should not be present; bool/filter alone handles all cases'
+        )

--- a/tests/agents/security_advisories/test_action_groups_tickets.py
+++ b/tests/agents/security_advisories/test_action_groups_tickets.py
@@ -1,0 +1,147 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke tests for ticket-related action group definitions.
+
+Validates: Requirements 3.1, 3.2, 3.3, 3.4, 7.1
+"""
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Path to the action_groups module
+_AGENTS_PATH = os.path.join(
+    os.path.dirname(__file__), '..', '..', '..', 'agents', 'security_advisories',
+)
+
+
+def _load_action_groups():
+    """Import action_groups with mocked aws_cdk."""
+    if _AGENTS_PATH not in sys.path:
+        sys.path.insert(0, _AGENTS_PATH)
+
+    # Mock aws_cdk.aws_bedrock so we can inspect the raw values passed to constructors
+    mock_bedrock = MagicMock()
+
+    # Make CDK construct calls return plain dicts for easy inspection
+    mock_bedrock.CfnAgent.FunctionProperty = lambda **kwargs: kwargs
+    mock_bedrock.CfnAgent.ParameterDetailProperty = lambda **kwargs: kwargs
+    mock_bedrock.CfnAgent.AgentActionGroupProperty = lambda **kwargs: kwargs
+    mock_bedrock.CfnAgent.ActionGroupExecutorProperty = lambda **kwargs: kwargs
+    mock_bedrock.CfnAgent.FunctionSchemaProperty = lambda **kwargs: kwargs
+
+    mock_cdk = MagicMock()
+    mock_cdk.aws_bedrock = mock_bedrock
+
+    with patch.dict('sys.modules', {
+        'aws_cdk': mock_cdk,
+        'aws_cdk.aws_bedrock': mock_bedrock,
+    }):
+        spec = importlib.util.spec_from_file_location(
+            'sa_action_groups',
+            os.path.join(_AGENTS_PATH, 'action_groups.py'),
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+
+@pytest.fixture(scope="module")
+def action_groups():
+    """Load action groups once for all tests in this module."""
+    mod = _load_action_groups()
+    return mod.get_action_groups('arn:aws:lambda:us-east-1:123:function:test')
+
+
+@pytest.fixture(scope="module")
+def functions(action_groups):
+    """Extract the functions list from the first (privileged) action group."""
+    ag = action_groups[0]
+    return ag['function_schema']['functions']
+
+
+@pytest.fixture(scope="module")
+def query_tickets_func(functions):
+    """Find the query_tickets function definition."""
+    matches = [f for f in functions if f['name'] == 'query_tickets']
+    assert len(matches) == 1, "Expected exactly one query_tickets function"
+    return matches[0]
+
+
+@pytest.fixture(scope="module")
+def list_ticket_projects_func(functions):
+    """Find the list_ticket_projects function definition."""
+    matches = [f for f in functions if f['name'] == 'list_ticket_projects']
+    assert len(matches) == 1, "Expected exactly one list_ticket_projects function"
+    return matches[0]
+
+
+class TestQueryTicketsFunction:
+    """Requirement 3.1: query_tickets function exists with correct definition."""
+
+    def test_function_exists(self, query_tickets_func):
+        assert query_tickets_func['name'] == 'query_tickets'
+
+    def test_function_has_description(self, query_tickets_func):
+        desc = query_tickets_func['description']
+        assert 'ticket' in desc.lower()
+        assert 'CVE' in desc or 'cve' in desc.lower()
+
+    def test_cve_id_parameter_exists(self, query_tickets_func):
+        """Requirement 3.2: cve_id parameter of type string, optional."""
+        params = query_tickets_func['parameters']
+        assert 'cve_id' in params
+
+    def test_cve_id_parameter_type(self, query_tickets_func):
+        params = query_tickets_func['parameters']
+        assert params['cve_id']['type'] == 'string'
+
+    def test_cve_id_parameter_not_required(self, query_tickets_func):
+        params = query_tickets_func['parameters']
+        assert params['cve_id']['required'] is False
+
+    def test_project_name_parameter_exists(self, query_tickets_func):
+        """Requirement 3.3: project_name parameter of type string, optional."""
+        params = query_tickets_func['parameters']
+        assert 'project_name' in params
+
+    def test_project_name_parameter_type(self, query_tickets_func):
+        params = query_tickets_func['parameters']
+        assert params['project_name']['type'] == 'string'
+
+    def test_project_name_parameter_not_required(self, query_tickets_func):
+        params = query_tickets_func['parameters']
+        assert params['project_name']['required'] is False
+
+    def test_branch_parameter_exists(self, query_tickets_func):
+        """Requirement 3.4: branch parameter of type string, optional."""
+        params = query_tickets_func['parameters']
+        assert 'branch' in params
+
+    def test_branch_parameter_type(self, query_tickets_func):
+        params = query_tickets_func['parameters']
+        assert params['branch']['type'] == 'string'
+
+    def test_branch_parameter_not_required(self, query_tickets_func):
+        params = query_tickets_func['parameters']
+        assert params['branch']['required'] is False
+
+
+class TestListTicketProjectsFunction:
+    """Requirement 7.1: list_ticket_projects function exists with correct definition."""
+
+    def test_function_exists(self, list_ticket_projects_func):
+        assert list_ticket_projects_func['name'] == 'list_ticket_projects'
+
+    def test_function_has_description(self, list_ticket_projects_func):
+        desc = list_ticket_projects_func['description']
+        assert 'project' in desc.lower()
+        assert 'ticket' in desc.lower()
+
+    def test_empty_parameters(self, list_ticket_projects_func):
+        params = list_ticket_projects_func['parameters']
+        assert params == {}

--- a/tests/agents/security_advisories/test_lambda_function.py
+++ b/tests/agents/security_advisories/test_lambda_function.py
@@ -57,6 +57,7 @@ def _load_lambda_function(
     mock_config=None,
     mock_vuln_handler=None,
     mock_proj_handler=None,
+    mock_tickets_handler=None,
     mock_response_builder=None,
 ):
     """Import lambda_function with mocked dependencies."""
@@ -72,6 +73,14 @@ def _load_lambda_function(
         mock_proj_handler.handle_list_projects = MagicMock(
             return_value={'status': 'success', 'projects': []},
         )
+    if mock_tickets_handler is None:
+        mock_tickets_handler = MagicMock()
+        mock_tickets_handler.handle_query_tickets = MagicMock(
+            return_value={'status': 'success', 'result_count': 0, 'results': []},
+        )
+        mock_tickets_handler.handle_list_ticket_projects = MagicMock(
+            return_value={'status': 'success', 'projects': []},
+        )
     if mock_response_builder is None:
         mock_response_builder = _make_mock_response_builder()
 
@@ -79,6 +88,7 @@ def _load_lambda_function(
         'config': mock_config,
         'vulnerabilities_handler': mock_vuln_handler,
         'projects_handler': mock_proj_handler,
+        'tickets_handler': mock_tickets_handler,
         'response_builder': mock_response_builder,
     }):
         spec = importlib.util.spec_from_file_location(
@@ -87,7 +97,7 @@ def _load_lambda_function(
         )
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
-        return mod, mock_vuln_handler, mock_proj_handler, mock_response_builder
+        return mod, mock_vuln_handler, mock_proj_handler, mock_tickets_handler, mock_response_builder
 
 
 # ---------------------------------------------------------------------------
@@ -103,7 +113,7 @@ class TestRoutingToQueryVulnerabilities:
         mock_vuln.handle_query_vulnerabilities = MagicMock(
             return_value={'status': 'success', 'results': []},
         )
-        mod, _, _, _ = _load_lambda_function(mock_vuln_handler=mock_vuln)
+        mod, _, _, _, _ = _load_lambda_function(mock_vuln_handler=mock_vuln)
 
         event = {
             'function': 'query_vulnerabilities',
@@ -122,7 +132,7 @@ class TestRoutingToQueryVulnerabilities:
         mock_vuln.handle_query_vulnerabilities = MagicMock(
             return_value={'status': 'success', 'results': []},
         )
-        mod, _, _, _ = _load_lambda_function(mock_vuln_handler=mock_vuln)
+        mod, _, _, _, _ = _load_lambda_function(mock_vuln_handler=mock_vuln)
 
         event = {
             'function': 'query_vulnerabilities',
@@ -151,7 +161,7 @@ class TestRoutingToListProjects:
         mock_proj.handle_list_projects = MagicMock(
             return_value={'status': 'success', 'projects': []},
         )
-        mod, _, _, _ = _load_lambda_function(mock_proj_handler=mock_proj)
+        mod, _, _, _, _ = _load_lambda_function(mock_proj_handler=mock_proj)
 
         event = {
             'function': 'list_projects',
@@ -168,7 +178,7 @@ class TestRoutingToListProjects:
         mock_proj.handle_list_projects = MagicMock(
             return_value={'status': 'success', 'projects': []},
         )
-        mod, _, _, _ = _load_lambda_function(mock_proj_handler=mock_proj)
+        mod, _, _, _, _ = _load_lambda_function(mock_proj_handler=mock_proj)
 
         event = {
             'function': 'list_projects',
@@ -193,7 +203,7 @@ class TestUnknownFunctionHandling:
     """Test unknown function name returns error with available_functions."""
 
     def test_unknown_function_returns_error(self):
-        mod, _, _, _ = _load_lambda_function()
+        mod, _, _, _, _ = _load_lambda_function()
 
         event = {
             'function': 'nonexistent_function',
@@ -210,7 +220,7 @@ class TestUnknownFunctionHandling:
         assert 'nonexistent_function' in body['message']
 
     def test_unknown_function_includes_available_functions(self):
-        mod, _, _, _ = _load_lambda_function()
+        mod, _, _, _, _ = _load_lambda_function()
 
         event = {
             'function': 'nonexistent_function',
@@ -228,7 +238,7 @@ class TestUnknownFunctionHandling:
         assert 'list_projects' in body['available_functions']
 
     def test_empty_function_name_returns_error(self):
-        mod, _, _, _ = _load_lambda_function()
+        mod, _, _, _, _ = _load_lambda_function()
 
         event = {
             'function': '',
@@ -254,7 +264,7 @@ class TestParameterParsing:
     """Test parameter parsing from Bedrock event format."""
 
     def test_parse_parameters_from_list(self):
-        mod, _, _, _ = _load_lambda_function()
+        mod, _, _, _, _ = _load_lambda_function()
 
         params = mod._parse_parameters([
             {'name': 'query', 'value': 'Show CVEs'},
@@ -264,14 +274,14 @@ class TestParameterParsing:
         assert params == {'query': 'Show CVEs', 'version': '2.19.6'}
 
     def test_parse_empty_parameters(self):
-        mod, _, _, _ = _load_lambda_function()
+        mod, _, _, _, _ = _load_lambda_function()
 
         params = mod._parse_parameters([])
 
         assert params == {}
 
     def test_parse_ignores_malformed_entries(self):
-        mod, _, _, _ = _load_lambda_function()
+        mod, _, _, _, _ = _load_lambda_function()
 
         params = mod._parse_parameters([
             {'name': 'query', 'value': 'Show CVEs'},
@@ -287,7 +297,7 @@ class TestParameterParsing:
         mock_vuln.handle_query_vulnerabilities = MagicMock(
             return_value={'status': 'success', 'results': []},
         )
-        mod, _, _, _ = _load_lambda_function(mock_vuln_handler=mock_vuln)
+        mod, _, _, _, _ = _load_lambda_function(mock_vuln_handler=mock_vuln)
 
         event = {
             'function': 'query_vulnerabilities',
@@ -311,7 +321,7 @@ class TestResponseEnvelope:
     """Test Bedrock response envelope structure."""
 
     def test_response_has_message_version(self):
-        mod, _, _, _ = _load_lambda_function()
+        mod, _, _, _, _ = _load_lambda_function()
 
         event = {
             'function': 'list_projects',
@@ -324,7 +334,7 @@ class TestResponseEnvelope:
         assert response['messageVersion'] == '1.0'
 
     def test_response_has_action_group(self):
-        mod, _, _, _ = _load_lambda_function()
+        mod, _, _, _, _ = _load_lambda_function()
 
         event = {
             'function': 'list_projects',
@@ -336,7 +346,7 @@ class TestResponseEnvelope:
         assert response['response']['actionGroup'] == 'securityAdvisoriesActions'
 
     def test_response_has_function_name(self):
-        mod, _, _, _ = _load_lambda_function()
+        mod, _, _, _, _ = _load_lambda_function()
 
         event = {
             'function': 'list_projects',
@@ -348,7 +358,7 @@ class TestResponseEnvelope:
         assert response['response']['function'] == 'list_projects'
 
     def test_response_body_is_json_string(self):
-        mod, _, _, _ = _load_lambda_function()
+        mod, _, _, _, _ = _load_lambda_function()
 
         event = {
             'function': 'list_projects',
@@ -363,7 +373,7 @@ class TestResponseEnvelope:
 
     def test_create_response_called_with_event_and_result(self):
         mock_rb = _make_mock_response_builder()
-        mod, _, _, _ = _load_lambda_function(mock_response_builder=mock_rb)
+        mod, _, _, _, _ = _load_lambda_function(mock_response_builder=mock_rb)
 
         event = {
             'function': 'list_projects',
@@ -387,7 +397,7 @@ class TestLambdaContextHandling:
 
     def test_sets_request_id_from_context(self):
         mock_config = _make_mock_config()
-        mod, _, _, _ = _load_lambda_function(mock_config=mock_config)
+        mod, _, _, _, _ = _load_lambda_function(mock_config=mock_config)
 
         mock_context = MagicMock()
         mock_context.aws_request_id = 'lambda-req-123'
@@ -402,7 +412,7 @@ class TestLambdaContextHandling:
         mock_config.config.set_request_id.assert_called_once_with('lambda-req-123')
 
     def test_handles_none_context(self):
-        mod, _, _, _ = _load_lambda_function()
+        mod, _, _, _, _ = _load_lambda_function()
 
         event = {
             'function': 'list_projects',
@@ -413,3 +423,140 @@ class TestLambdaContextHandling:
         response = mod.lambda_handler(event, None)
 
         assert 'messageVersion' in response
+
+
+# ---------------------------------------------------------------------------
+# Routing tests for ticket functions
+# ---------------------------------------------------------------------------
+
+
+class TestRoutingToQueryTickets:
+    """Test routing to query_tickets handler.
+
+    **Validates: Requirements 3.5**
+    """
+
+    def test_routes_to_tickets_handler(self):
+        mock_tickets = MagicMock()
+        mock_tickets.handle_query_tickets = MagicMock(
+            return_value={'status': 'success', 'result_count': 0, 'results': []},
+        )
+        mock_tickets.handle_list_ticket_projects = MagicMock()
+        mod, _, _, _, _ = _load_lambda_function(mock_tickets_handler=mock_tickets)
+
+        event = {
+            'function': 'query_tickets',
+            'actionGroup': 'securityAdvisoriesActions',
+            'parameters': [
+                {'name': 'cve_id', 'value': 'CVE-2026-27903'},
+            ],
+        }
+        mod.lambda_handler(event, None)
+
+        mock_tickets.handle_query_tickets.assert_called_once()
+
+    def test_passes_parsed_params_to_handler(self):
+        mock_tickets = MagicMock()
+        mock_tickets.handle_query_tickets = MagicMock(
+            return_value={'status': 'success', 'result_count': 0, 'results': []},
+        )
+        mock_tickets.handle_list_ticket_projects = MagicMock()
+        mod, _, _, _, _ = _load_lambda_function(mock_tickets_handler=mock_tickets)
+
+        event = {
+            'function': 'query_tickets',
+            'actionGroup': 'securityAdvisoriesActions',
+            'parameters': [
+                {'name': 'cve_id', 'value': 'CVE-2026-27903'},
+                {'name': 'project_name', 'value': 'OpenSearch'},
+                {'name': 'branch', 'value': 'origin/main'},
+            ],
+        }
+        mod.lambda_handler(event, None)
+
+        call_args = mock_tickets.handle_query_tickets.call_args
+        params = call_args[0][0]
+        assert params['cve_id'] == 'CVE-2026-27903'
+        assert params['project_name'] == 'OpenSearch'
+        assert params['branch'] == 'origin/main'
+
+
+class TestRoutingToListTicketProjects:
+    """Test routing to list_ticket_projects handler.
+
+    **Validates: Requirements 7.2**
+    """
+
+    def test_routes_to_tickets_handler(self):
+        mock_tickets = MagicMock()
+        mock_tickets.handle_query_tickets = MagicMock()
+        mock_tickets.handle_list_ticket_projects = MagicMock(
+            return_value={'status': 'success', 'projects': []},
+        )
+        mod, _, _, _, _ = _load_lambda_function(mock_tickets_handler=mock_tickets)
+
+        event = {
+            'function': 'list_ticket_projects',
+            'actionGroup': 'securityAdvisoriesActions',
+            'parameters': [],
+        }
+        mod.lambda_handler(event, None)
+
+        mock_tickets.handle_list_ticket_projects.assert_called_once()
+
+    def test_receives_request_id(self):
+        mock_tickets = MagicMock()
+        mock_tickets.handle_query_tickets = MagicMock()
+        mock_tickets.handle_list_ticket_projects = MagicMock(
+            return_value={'status': 'success', 'projects': []},
+        )
+        mod, _, _, _, _ = _load_lambda_function(mock_tickets_handler=mock_tickets)
+
+        event = {
+            'function': 'list_ticket_projects',
+            'actionGroup': 'securityAdvisoriesActions',
+            'parameters': [],
+        }
+        mod.lambda_handler(event, None)
+
+        call_args = mock_tickets.handle_list_ticket_projects.call_args
+        request_id = call_args[0][0]
+        assert isinstance(request_id, str)
+        assert len(request_id) > 0
+
+
+class TestTicketFunctionsInAvailableFunctions:
+    """Test new functions appear in available_functions error response.
+
+    **Validates: Requirements 3.5, 7.2**
+    """
+
+    def test_query_tickets_in_available_functions(self):
+        mod, _, _, _, _ = _load_lambda_function()
+
+        event = {
+            'function': 'nonexistent_function',
+            'actionGroup': 'securityAdvisoriesActions',
+            'parameters': [],
+        }
+        response = mod.lambda_handler(event, None)
+
+        body = json.loads(
+            response['response']['functionResponse']['responseBody']['TEXT']['body'],
+        )
+        assert 'query_tickets' in body['available_functions']
+
+    def test_list_ticket_projects_in_available_functions(self):
+        mod, _, _, _, _ = _load_lambda_function()
+
+        event = {
+            'function': 'nonexistent_function',
+            'actionGroup': 'securityAdvisoriesActions',
+            'parameters': [],
+        }
+        response = mod.lambda_handler(event, None)
+
+        body = json.loads(
+            response['response']['functionResponse']['responseBody']['TEXT']['body'],
+        )
+        assert 'list_ticket_projects' in body['available_functions']

--- a/tests/agents/security_advisories/test_resolve_version_tag.py
+++ b/tests/agents/security_advisories/test_resolve_version_tag.py
@@ -1,11 +1,11 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for resolve_version_tag in dsl_query_builder.
+"""Tests for resolve_version_tag in query_utils.
 
 Covers:
 - resolve_version_tag: maps user-provided versions to the canonical
-  origin/{major}.{minor} tag format used in the scans index.
+  origin/{major}.{minor} tag format used in the scans and tickets indices.
 """
 
 import importlib
@@ -19,7 +19,7 @@ _LAMBDA_PATH = os.path.join(
 
 
 def _load_dsl_query_builder():
-    """Import dsl_query_builder with mocked aws_utils."""
+    """Import query_utils with mocked aws_utils."""
     if _LAMBDA_PATH not in sys.path:
         sys.path.insert(0, _LAMBDA_PATH)
 
@@ -35,7 +35,7 @@ def _load_dsl_query_builder():
         'config': mock_config_module,
     }):
         spec = importlib.util.spec_from_file_location(
-            'sa_dsl_query_builder_resolve', os.path.join(_LAMBDA_PATH, 'dsl_query_builder.py'),
+            'sa_query_utils_resolve', os.path.join(_LAMBDA_PATH, 'query_utils.py'),
         )
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)

--- a/tests/agents/security_advisories/test_tickets_handler.py
+++ b/tests/agents/security_advisories/test_tickets_handler.py
@@ -52,9 +52,18 @@ def _load_tickets_handler(mock_opensearch_request=None):
     mock_tickets_query_builder.build_tickets_query = MagicMock(return_value={})
     mock_tickets_query_builder.build_list_projects_query = MagicMock(return_value={})
 
+    # Load the real query_utils module so error_response/connection_error work
+    query_utils_spec = importlib.util.spec_from_file_location(
+        'query_utils',
+        os.path.join(_LAMBDA_PATH, 'query_utils.py'),
+    )
+    query_utils_mod = importlib.util.module_from_spec(query_utils_spec)
+    query_utils_spec.loader.exec_module(query_utils_mod)
+
     with patch.dict('sys.modules', {
         'aws_utils': mock_aws_utils,
         'config': mock_config,
+        'query_utils': query_utils_mod,
         'tickets_query_builder': mock_tickets_query_builder,
     }):
         spec = importlib.util.spec_from_file_location(
@@ -311,9 +320,9 @@ class TestQueryTicketsConnectionError:
     """
 
     def test_connection_error_response(self):
-        """ConnectionError produces a connection_error typed response."""
+        """ConnectionError produces a sanitized connection_error typed response."""
         mock_opensearch_request = MagicMock(
-            side_effect=ConnectionError('Failed to connect'),
+            side_effect=ConnectionError('socket timeout on 10.0.1.42:9200'),
         )
         mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
 
@@ -321,8 +330,13 @@ class TestQueryTicketsConnectionError:
 
         assert result['status'] == 'error'
         assert result['type'] == 'connection_error'
+        assert result['retryable'] is False
         assert 'message' in result
-        assert 'Failed to connect' in result['message']
+        # Sanitized message should NOT contain raw internal details
+        assert '10.0.1.42' not in result['message']
+        assert 'socket timeout' not in result['message']
+        # Should contain the generic sanitized message
+        assert 'OpenSearch cluster' in result['message']
 
 
 class TestQueryTicketsOpenSearchError:
@@ -332,9 +346,9 @@ class TestQueryTicketsOpenSearchError:
     """
 
     def test_opensearch_error_response(self):
-        """OpenSearch request failure produces an opensearch_error typed response."""
+        """RuntimeError from opensearch_request produces an opensearch_error typed response."""
         mock_opensearch_request = MagicMock(
-            side_effect=Exception('OpenSearch request failed: 400 - Bad Request'),
+            side_effect=RuntimeError('OpenSearch request failed: 400 - Bad Request'),
         )
         mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
 
@@ -342,6 +356,7 @@ class TestQueryTicketsOpenSearchError:
 
         assert result['status'] == 'error'
         assert result['type'] == 'opensearch_error'
+        assert result['retryable'] is False
         assert 'message' in result
         assert 'OpenSearch request failed' in result['message']
 
@@ -372,9 +387,9 @@ class TestListTicketProjectsConnectionError:
     """
 
     def test_connection_error_response(self):
-        """ConnectionError produces a connection_error typed response."""
+        """ConnectionError produces a sanitized connection_error typed response."""
         mock_opensearch_request = MagicMock(
-            side_effect=ConnectionError('Failed to connect'),
+            side_effect=ConnectionError('socket timeout on 10.0.1.42:9200'),
         )
         mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
 
@@ -382,7 +397,13 @@ class TestListTicketProjectsConnectionError:
 
         assert result['status'] == 'error'
         assert result['type'] == 'connection_error'
+        assert result['retryable'] is False
         assert 'message' in result
+        # Sanitized message should NOT contain raw internal details
+        assert '10.0.1.42' not in result['message']
+        assert 'socket timeout' not in result['message']
+        # Should contain the generic sanitized message
+        assert 'OpenSearch cluster' in result['message']
 
 
 class TestListTicketProjectsOpenSearchError:
@@ -392,9 +413,9 @@ class TestListTicketProjectsOpenSearchError:
     """
 
     def test_opensearch_error_response(self):
-        """OpenSearch request failure produces an opensearch_error typed response."""
+        """RuntimeError from opensearch_request produces an opensearch_error typed response."""
         mock_opensearch_request = MagicMock(
-            side_effect=Exception('OpenSearch request failed: 500 - Internal Server Error'),
+            side_effect=RuntimeError('OpenSearch request failed: 500 - Internal Server Error'),
         )
         mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
 
@@ -402,6 +423,7 @@ class TestListTicketProjectsOpenSearchError:
 
         assert result['status'] == 'error'
         assert result['type'] == 'opensearch_error'
+        assert result['retryable'] is False
         assert 'message' in result
         assert 'OpenSearch request failed' in result['message']
 

--- a/tests/agents/security_advisories/test_tickets_handler.py
+++ b/tests/agents/security_advisories/test_tickets_handler.py
@@ -1,0 +1,437 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Property-based and unit tests for tickets_handler.py.
+
+These tests verify universal correctness properties of the tickets handler
+module across many randomly generated inputs, plus example-based tests for
+specific scenarios and error handling.
+
+**Validates Property 2: Response field filtering**
+**Validates Property 3: Result count consistency**
+**Validates Property 4: Project extraction from collapsed hits**
+"""
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+# Path to the real lambda module
+_LAMBDA_PATH = os.path.join(
+    os.path.dirname(__file__), '..', '..', '..', 'agents', 'security_advisories', 'lambda',
+)
+
+
+def _load_tickets_handler(mock_opensearch_request=None):
+    """Import tickets_handler with mocked dependencies.
+
+    Args:
+        mock_opensearch_request: A MagicMock or callable to use as
+            aws_utils.opensearch_request. If None, defaults to returning
+            empty hits.
+
+    Returns:
+        Tuple of (module, mock_aws_utils, mock_tickets_query_builder).
+    """
+    if _LAMBDA_PATH not in sys.path:
+        sys.path.insert(0, _LAMBDA_PATH)
+
+    mock_aws_utils = MagicMock()
+    if mock_opensearch_request is not None:
+        mock_aws_utils.opensearch_request = mock_opensearch_request
+    else:
+        mock_aws_utils.opensearch_request = MagicMock(return_value={'hits': {'hits': []}})
+
+    mock_config = MagicMock()
+
+    mock_tickets_query_builder = MagicMock()
+    mock_tickets_query_builder.build_tickets_query = MagicMock(return_value={})
+    mock_tickets_query_builder.build_list_projects_query = MagicMock(return_value={})
+
+    with patch.dict('sys.modules', {
+        'aws_utils': mock_aws_utils,
+        'config': mock_config,
+        'tickets_query_builder': mock_tickets_query_builder,
+    }):
+        spec = importlib.util.spec_from_file_location(
+            'sa_tickets_handler',
+            os.path.join(_LAMBDA_PATH, 'tickets_handler.py'),
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod, mock_aws_utils, mock_tickets_query_builder
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis Strategies
+# ---------------------------------------------------------------------------
+
+# Strategy for extra fields that might appear in _source documents
+_extra_field_keys = st.sampled_from([
+    'cveId', 'projectName', 'branches', 'status', 'severity',
+    'createdAt', 'timestamp',
+])
+
+_extra_field_values = st.one_of(
+    st.text(min_size=0, max_size=50),
+    st.lists(st.text(min_size=1, max_size=20), max_size=5),
+    st.integers(),
+    st.booleans(),
+)
+
+# Strategy for a _source dict: always has ticketId plus random extra fields
+_ticket_source = st.builds(
+    lambda ticket_id, extras: {'ticketId': ticket_id, **extras},
+    ticket_id=st.text(min_size=1, max_size=30),
+    extras=st.dictionaries(
+        keys=_extra_field_keys,
+        values=_extra_field_values,
+        min_size=0,
+        max_size=7,
+    ),
+)
+
+# Strategy for a list of OpenSearch hit dicts
+_hits_strategy = st.lists(
+    _ticket_source.map(lambda source: {'_source': source}),
+    min_size=0,
+    max_size=20,
+)
+
+
+# ---------------------------------------------------------------------------
+# Feature: ticket-query, Property 2: Response field filtering
+# ---------------------------------------------------------------------------
+
+
+class TestResponseFieldFiltering:
+    """Property 2: Response field filtering — only permitted fields in results.
+
+    For any set of ticket documents returned from OpenSearch (containing
+    arbitrary combinations of fields like ticketId, cveId, projectName,
+    branches, status, severity, createdAt, timestamp), the handler SHALL
+    produce result objects containing only the key `ticketId`. No other
+    fields from the source document SHALL appear in the response.
+
+    **Validates: Requirements 1.2, 2.2, 5.4, 8.2**
+    """
+
+    @given(hits=_hits_strategy)
+    @settings(max_examples=100)
+    def test_only_ticket_id_in_results(self, hits):
+        """Regardless of extra fields in _source, only ticketId appears in results."""
+        opensearch_response = {'hits': {'hits': hits}}
+
+        mock_opensearch_request = MagicMock(return_value=opensearch_response)
+        mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
+
+        result = mod.handle_query_tickets({'cve_id': 'CVE-2024-0001'}, 'test-prop2')
+
+        assert result['status'] == 'success'
+        for entry in result['results']:
+            assert set(entry.keys()) == {'ticketId', 'ticket_url'}, (
+                f'Expected only "ticketId" and "ticket_url" keys but got keys: {set(entry.keys())}'
+            )
+            assert entry['ticket_url'] == f'https://t.corp.amazon.com/{entry["ticketId"]}', (
+                f'ticket_url should be https://t.corp.amazon.com/{entry["ticketId"]}, '
+                f'got {entry["ticket_url"]}'
+            )
+
+
+# ---------------------------------------------------------------------------
+# Feature: ticket-query, Property 3: Result count consistency
+# ---------------------------------------------------------------------------
+
+
+class TestResultCountConsistency:
+    """Property 3: Result count consistency.
+
+    For any handler response with status "success", the result_count field
+    SHALL always equal the length of the results array.
+
+    **Validates: Requirements 5.2, 5.3**
+    """
+
+    @given(
+        hits=st.lists(
+            st.fixed_dictionaries({
+                '_source': st.fixed_dictionaries({
+                    'ticketId': st.text(min_size=1, max_size=20),
+                }),
+            }),
+            min_size=0,
+            max_size=50,
+        ),
+    )
+    @settings(max_examples=100)
+    def test_result_count_equals_results_length(self, hits):
+        """result_count always equals len(results) for any number of hits.
+
+        **Validates: Requirements 5.2, 5.3**
+        """
+        mock_opensearch_request = MagicMock(
+            return_value={'hits': {'hits': hits}},
+        )
+        mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
+
+        response = mod.handle_query_tickets({'cve_id': 'CVE-2024-0001'}, 'test-req')
+
+        assert response['status'] == 'success'
+        assert response['result_count'] == len(response['results'])
+
+    @given(
+        hits=st.lists(
+            st.fixed_dictionaries({
+                '_source': st.fixed_dictionaries({
+                    'ticketId': st.text(min_size=1, max_size=20),
+                }),
+            }),
+            min_size=0,
+            max_size=0,
+        ),
+    )
+    @settings(max_examples=100)
+    def test_empty_results_has_zero_count(self, hits):
+        """When results is empty, result_count is 0.
+
+        **Validates: Requirements 5.2, 5.3**
+        """
+        mock_opensearch_request = MagicMock(
+            return_value={'hits': {'hits': hits}},
+        )
+        mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
+
+        response = mod.handle_query_tickets({'cve_id': 'CVE-2024-0001'}, 'test-req')
+
+        assert response['status'] == 'success'
+        assert response['result_count'] == 0
+        assert response['results'] == []
+
+
+# ---------------------------------------------------------------------------
+# Feature: ticket-query, Property 4: Project extraction from collapsed hits
+# ---------------------------------------------------------------------------
+
+
+class TestProjectExtractionFromCollapsedHits:
+    """Property 4: Project extraction from collapsed hits.
+
+    For any list of OpenSearch hit documents containing _source.projectName
+    values, the handle_list_ticket_projects handler SHALL extract exactly the
+    set of projectName values — one per hit — producing a projects array whose
+    elements match the input projectName values with no duplicates introduced
+    by the handler itself.
+
+    **Validates: Requirements 7.3, 7.4**
+    """
+
+    @given(project_names=st.lists(st.text(min_size=1), min_size=0, max_size=30))
+    @settings(max_examples=100)
+    def test_extracted_projects_match_input_project_names(self, project_names):
+        """Extracted projects match input projectName values exactly.
+
+        **Validates: Requirements 7.3, 7.4**
+        """
+        generated_hits = [{"_source": {"projectName": name}} for name in project_names]
+
+        mock_opensearch_request = MagicMock(
+            return_value={"hits": {"hits": generated_hits}},
+        )
+
+        mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
+
+        response = mod.handle_list_ticket_projects('test-req')
+
+        assert response['projects'] == project_names, (
+            f"Expected projects {project_names}, got {response['projects']}"
+        )
+
+    @given(project_names=st.lists(st.text(min_size=1), min_size=0, max_size=30))
+    @settings(max_examples=100)
+    def test_no_duplicates_introduced_by_handler(self, project_names):
+        """The handler does not introduce duplicates beyond what is in the input.
+
+        **Validates: Requirements 7.3, 7.4**
+        """
+        generated_hits = [{"_source": {"projectName": name}} for name in project_names]
+
+        mock_opensearch_request = MagicMock(
+            return_value={"hits": {"hits": generated_hits}},
+        )
+
+        mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
+
+        response = mod.handle_list_ticket_projects('test-req')
+
+        assert len(response['projects']) == len(project_names), (
+            f"Handler introduced duplicates: input had {len(project_names)} items, "
+            f"output has {len(response['projects'])} items"
+        )
+
+        for project in response['projects']:
+            assert project in project_names, (
+                f"Handler introduced a value '{project}' not in the input"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Unit Tests: Example-based tests for tickets_handler
+# Requirements: 1.3, 1.4, 2.3, 2.4, 5.2, 5.3, 7.6, 7.7
+# ---------------------------------------------------------------------------
+
+
+class TestQueryTicketsEmptyResults:
+    """Test query_tickets returns correct response when no hits found.
+
+    **Validates: Requirements 1.3, 5.2, 5.3**
+    """
+
+    def test_empty_results_response(self):
+        """Empty hits returns success with result_count 0 and empty results."""
+        mock_opensearch_request = MagicMock(return_value={'hits': {'hits': []}})
+        mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
+
+        result = mod.handle_query_tickets({'cve_id': 'CVE-2024-0001'}, 'req-123')
+
+        assert result == {
+            'status': 'success',
+            'result_count': 0,
+            'results': [],
+        }
+
+
+class TestQueryTicketsConnectionError:
+    """Test query_tickets handles connection errors correctly.
+
+    **Validates: Requirements 1.4, 2.4**
+    """
+
+    def test_connection_error_response(self):
+        """ConnectionError produces a connection_error typed response."""
+        mock_opensearch_request = MagicMock(
+            side_effect=ConnectionError('Failed to connect'),
+        )
+        mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
+
+        result = mod.handle_query_tickets({'cve_id': 'CVE-2024-0001'}, 'req-123')
+
+        assert result['status'] == 'error'
+        assert result['type'] == 'connection_error'
+        assert 'message' in result
+        assert 'Failed to connect' in result['message']
+
+
+class TestQueryTicketsOpenSearchError:
+    """Test query_tickets handles OpenSearch errors correctly.
+
+    **Validates: Requirements 1.4, 2.4**
+    """
+
+    def test_opensearch_error_response(self):
+        """OpenSearch request failure produces an opensearch_error typed response."""
+        mock_opensearch_request = MagicMock(
+            side_effect=Exception('OpenSearch request failed: 400 - Bad Request'),
+        )
+        mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
+
+        result = mod.handle_query_tickets({'cve_id': 'CVE-2024-0001'}, 'req-123')
+
+        assert result['status'] == 'error'
+        assert result['type'] == 'opensearch_error'
+        assert 'message' in result
+        assert 'OpenSearch request failed' in result['message']
+
+
+class TestListTicketProjectsEmptyState:
+    """Test list_ticket_projects returns correct response when no projects found.
+
+    **Validates: Requirements 7.6**
+    """
+
+    def test_empty_projects_response(self):
+        """Empty hits returns success with empty projects array."""
+        mock_opensearch_request = MagicMock(return_value={'hits': {'hits': []}})
+        mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
+
+        result = mod.handle_list_ticket_projects('req-123')
+
+        assert result == {
+            'status': 'success',
+            'projects': [],
+        }
+
+
+class TestListTicketProjectsConnectionError:
+    """Test list_ticket_projects handles connection errors correctly.
+
+    **Validates: Requirements 7.7**
+    """
+
+    def test_connection_error_response(self):
+        """ConnectionError produces a connection_error typed response."""
+        mock_opensearch_request = MagicMock(
+            side_effect=ConnectionError('Failed to connect'),
+        )
+        mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
+
+        result = mod.handle_list_ticket_projects('req-123')
+
+        assert result['status'] == 'error'
+        assert result['type'] == 'connection_error'
+        assert 'message' in result
+
+
+class TestListTicketProjectsOpenSearchError:
+    """Test list_ticket_projects handles OpenSearch errors correctly.
+
+    **Validates: Requirements 7.7**
+    """
+
+    def test_opensearch_error_response(self):
+        """OpenSearch request failure produces an opensearch_error typed response."""
+        mock_opensearch_request = MagicMock(
+            side_effect=Exception('OpenSearch request failed: 500 - Internal Server Error'),
+        )
+        mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
+
+        result = mod.handle_list_ticket_projects('req-123')
+
+        assert result['status'] == 'error'
+        assert result['type'] == 'opensearch_error'
+        assert 'message' in result
+        assert 'OpenSearch request failed' in result['message']
+
+
+class TestQueryTicketsWithResults:
+    """Test query_tickets correctly extracts ticketId from hits.
+
+    **Validates: Requirements 1.2, 2.2, 5.2**
+    """
+
+    def test_results_extracted_correctly(self):
+        """Hits with ticketIds are extracted into results array."""
+        opensearch_response = {
+            'hits': {
+                'hits': [
+                    {'_source': {'ticketId': 'V123456'}},
+                    {'_source': {'ticketId': 'V123457'}},
+                    {'_source': {'ticketId': 'V123458'}},
+                ],
+            },
+        }
+        mock_opensearch_request = MagicMock(return_value=opensearch_response)
+        mod, _, _ = _load_tickets_handler(mock_opensearch_request=mock_opensearch_request)
+
+        result = mod.handle_query_tickets({'cve_id': 'CVE-2024-0001'}, 'req-123')
+
+        assert result['status'] == 'success'
+        assert result['result_count'] == 3
+        assert result['results'] == [
+            {'ticketId': 'V123456', 'ticket_url': 'https://t.corp.amazon.com/V123456'},
+            {'ticketId': 'V123457', 'ticket_url': 'https://t.corp.amazon.com/V123457'},
+            {'ticketId': 'V123458', 'ticket_url': 'https://t.corp.amazon.com/V123458'},
+        ]

--- a/tests/agents/security_advisories/test_tickets_handler.py
+++ b/tests/agents/security_advisories/test_tickets_handler.py
@@ -358,7 +358,7 @@ class TestQueryTicketsOpenSearchError:
         assert result['type'] == 'opensearch_error'
         assert result['retryable'] is False
         assert 'message' in result
-        assert 'OpenSearch request failed' in result['message']
+        assert result['message'] == 'OpenSearch query failed.'
 
 
 class TestListTicketProjectsEmptyState:
@@ -425,7 +425,7 @@ class TestListTicketProjectsOpenSearchError:
         assert result['type'] == 'opensearch_error'
         assert result['retryable'] is False
         assert 'message' in result
-        assert 'OpenSearch request failed' in result['message']
+        assert result['message'] == 'OpenSearch query failed.'
 
 
 class TestQueryTicketsWithResults:


### PR DESCRIPTION
### Description
Allows privileged users to retrieve SIM tickets by CVE, project, and branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
